### PR TITLE
Add Simple Mover proof-of-concept canvas game

### DIFF
--- a/simple-mover/index.html
+++ b/simple-mover/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Simple Mover</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="layout">
+    <section class="game-panel">
+      <canvas id="game" width="480" height="320" aria-label="Simple mover game" role="img"></canvas>
+    </section>
+    <section class="info-panel">
+      <h1>Simple Mover</h1>
+      <p>Use the arrow keys or WASD to move the blue square. Collect stars to gain points and avoid the red walls!</p>
+      <ul>
+        <li><strong>Arrow Keys / WASD</strong>: Move</li>
+        <li><strong>Space</strong>: Dash (short burst of speed)</li>
+      </ul>
+      <p>The game ends if you hit a wall. Refresh the page to play again.</p>
+    </section>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/simple-mover/script.js
+++ b/simple-mover/script.js
@@ -1,0 +1,205 @@
+const canvas = document.getElementById("game");
+const ctx = canvas.getContext("2d");
+
+const state = {
+  player: {
+    x: canvas.width / 2 - 16,
+    y: canvas.height / 2 - 16,
+    size: 32,
+    color: "#4db5ff",
+    speed: 150,
+    dashSpeed: 320,
+    dashCooldown: 0,
+  },
+  keys: new Set(),
+  star: null,
+  score: 0,
+  walls: [],
+  playing: true,
+};
+
+function randInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function createWalls() {
+  state.walls = [
+    { x: 40, y: 40, width: 400, height: 20 },
+    { x: 40, y: 260, width: 400, height: 20 },
+    { x: 40, y: 40, width: 20, height: 240 },
+    { x: 420, y: 40, width: 20, height: 240 },
+    { x: 150, y: 120, width: 180, height: 20 },
+    { x: 150, y: 200, width: 180, height: 20 },
+  ];
+}
+
+function spawnStar() {
+  const padding = 48;
+  let x;
+  let y;
+  const size = 14;
+
+  do {
+    x = randInt(padding, canvas.width - padding - size);
+    y = randInt(padding, canvas.height - padding - size);
+  } while (
+    state.walls.some((wall) =>
+      rectIntersect(
+        { x, y, width: size, height: size },
+        wall
+      )
+    )
+  );
+
+  state.star = { x, y, size, color: "#ffd966" };
+}
+
+function rectIntersect(a, b) {
+  return (
+    a.x < b.x + b.width &&
+    a.x + a.width > b.x &&
+    a.y < b.y + b.height &&
+    a.y + a.height > b.y
+  );
+}
+
+function updatePlayer(delta) {
+  if (!state.playing) {
+    return;
+  }
+
+  const p = state.player;
+  let dx = 0;
+  let dy = 0;
+
+  if (state.keys.has("ArrowLeft") || state.keys.has("a")) dx -= 1;
+  if (state.keys.has("ArrowRight") || state.keys.has("d")) dx += 1;
+  if (state.keys.has("ArrowUp") || state.keys.has("w")) dy -= 1;
+  if (state.keys.has("ArrowDown") || state.keys.has("s")) dy += 1;
+
+  const length = Math.hypot(dx, dy) || 1;
+  dx /= length;
+  dy /= length;
+
+  const isDashing = state.keys.has(" ") && state.player.dashCooldown <= 0;
+  const speed = isDashing ? p.dashSpeed : p.speed;
+
+  const distance = speed * delta;
+  const nextX = p.x + dx * distance;
+  const nextY = p.y + dy * distance;
+
+  const playerRect = { x: nextX, y: nextY, width: p.size, height: p.size };
+
+  if (state.walls.some((wall) => rectIntersect(playerRect, wall))) {
+    state.playing = false;
+    return;
+  }
+
+  p.x = Math.max(0, Math.min(canvas.width - p.size, nextX));
+  p.y = Math.max(0, Math.min(canvas.height - p.size, nextY));
+
+  if (isDashing) {
+    state.player.dashCooldown = 0.6;
+  }
+
+  if (state.player.dashCooldown > 0) {
+    state.player.dashCooldown -= delta;
+  }
+
+  if (state.player.dashCooldown < 0) {
+    state.player.dashCooldown = 0;
+  }
+
+  const starRect = {
+    x: state.star.x,
+    y: state.star.y,
+    width: state.star.size,
+    height: state.star.size,
+  };
+
+  if (rectIntersect(playerRect, starRect)) {
+    state.score += 1;
+    spawnStar();
+  }
+}
+
+function draw() {
+  ctx.fillStyle = "#030712";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.strokeStyle = "rgba(77, 181, 255, 0.4)";
+  ctx.lineWidth = 6;
+  ctx.strokeRect(15, 15, canvas.width - 30, canvas.height - 30);
+
+  state.walls.forEach((wall) => {
+    ctx.fillStyle = "#ff4d6d";
+    ctx.fillRect(wall.x, wall.y, wall.width, wall.height);
+  });
+
+  const p = state.player;
+  ctx.fillStyle = p.color;
+  ctx.fillRect(p.x, p.y, p.size, p.size);
+
+  if (state.star) {
+    ctx.save();
+    ctx.translate(state.star.x + state.star.size / 2, state.star.y + state.star.size / 2);
+    ctx.rotate(Date.now() / 300);
+    ctx.fillStyle = state.star.color;
+    ctx.beginPath();
+    for (let i = 0; i < 5; i++) {
+      ctx.lineTo(0, state.star.size / 2);
+      ctx.rotate((Math.PI * 2) / 10);
+      ctx.lineTo(0, state.star.size);
+      ctx.rotate((Math.PI * 2) / 10);
+    }
+    ctx.fill();
+    ctx.restore();
+  }
+
+  ctx.fillStyle = "#c7dfff";
+  ctx.font = "20px 'Segoe UI', sans-serif";
+  ctx.fillText(`Score: ${state.score}`, 24, 36);
+
+  if (!state.playing) {
+    ctx.fillStyle = "rgba(10, 12, 21, 0.8)";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "28px 'Segoe UI', sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("Game Over", canvas.width / 2, canvas.height / 2 - 10);
+    ctx.font = "18px 'Segoe UI', sans-serif";
+    ctx.fillText("Refresh the page to try again", canvas.width / 2, canvas.height / 2 + 20);
+    ctx.textAlign = "left";
+  }
+}
+
+let previous = performance.now();
+
+function loop(now) {
+  const delta = (now - previous) / 1000;
+  previous = now;
+
+  updatePlayer(delta);
+  draw();
+  requestAnimationFrame(loop);
+}
+
+function init() {
+  createWalls();
+  spawnStar();
+  requestAnimationFrame(loop);
+}
+
+window.addEventListener("keydown", (event) => {
+  state.keys.add(event.key);
+  if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", " ", "w", "a", "s", "d"].includes(event.key)) {
+    event.preventDefault();
+  }
+});
+
+window.addEventListener("keyup", (event) => {
+  state.keys.delete(event.key);
+});
+
+init();

--- a/simple-mover/styles.css
+++ b/simple-mover/styles.css
@@ -1,0 +1,74 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #101820;
+  color: #f0f6ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  padding: 2rem;
+  max-width: 960px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.game-panel {
+  background: linear-gradient(145deg, #162a3b, #0d1722);
+  padding: 1rem;
+  border-radius: 1rem;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.35);
+}
+
+canvas {
+  width: 100%;
+  height: auto;
+  border-radius: 0.75rem;
+  background: #05090f;
+  display: block;
+}
+
+.info-panel {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: 2.5rem;
+  line-height: 1.2;
+}
+
+p {
+  margin: 0;
+  color: #ced9ec;
+}
+
+ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #9fb6d4;
+}
+
+@media (max-width: 768px) {
+  .layout {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .info-panel {
+    align-items: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Simple Mover proof-of-concept game that runs entirely client-side
- implement canvas rendering, keyboard controls, star collection, and walls
- provide responsive layout and instructions for playing the game

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d915aad84c832caac550ea36ca445a