### PR TITLE
Expand simple mover playfield and add retry overlay

### DIFF
--- a/simple_mover/index.html
+++ b/simple_mover/index.html
@@ -9,7 +9,28 @@
 <body>
   <main class="layout">
     <section class="game-panel">
-      <canvas id="game" width="480" height="320" aria-label="Simple mover game" role="img"></canvas>
+      <div class="game-container">
+        <canvas
+          id="game"
+          width="960"
+          height="600"
+          aria-label="Simple mover game"
+          role="img"
+        ></canvas>
+        <div
+          id="game-over"
+          class="game-over"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="game-over-title"
+          hidden
+        >
+          <h2 id="game-over-title">Game Over</h2>
+          <p>You bumped into a wall, but you can try again!</p>
+          <p class="game-over__score">Your score: <span id="final-score">0</span></p>
+          <button id="retry-btn" type="button" class="retry-button">Play again</button>
+        </div>
+      </div>
     </section>
     <section class="info-panel">
       <h1>Simple Mover</h1>
@@ -18,7 +39,7 @@
         <li><strong>Arrow Keys / WASD</strong>: Move</li>
         <li><strong>Space</strong>: Dash (short burst of speed)</li>
       </ul>
-      <p>The game ends if you hit a wall. Refresh the page to play again.</p>
+      <p>The game ends if you hit a wall, but you can instantly restart from the retry popup.</p>
     </section>
   </main>
   <script src="script.js"></script>

--- a/simple_mover/styles.css
+++ b/simple_mover/styles.css
@@ -15,27 +15,76 @@ body {
 
 .layout {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 2rem;
-  padding: 2rem;
-  max-width: 960px;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: 2.5rem;
+  padding: 2.5rem;
+  max-width: 1400px;
   width: 100%;
   box-sizing: border-box;
 }
 
 .game-panel {
   background: linear-gradient(145deg, #162a3b, #0d1722);
-  padding: 1rem;
-  border-radius: 1rem;
-  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.35);
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  box-shadow: 0 2rem 3.5rem rgba(0, 0, 0, 0.4);
 }
 
 canvas {
   width: 100%;
   height: auto;
-  border-radius: 0.75rem;
+  border-radius: 0.85rem;
   background: #05090f;
   display: block;
+}
+
+.game-container {
+  position: relative;
+}
+
+.game-over {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  text-align: center;
+  background: rgba(6, 9, 15, 0.88);
+  padding: 2.5rem 2rem;
+  border-radius: 0.85rem;
+  backdrop-filter: blur(4px);
+}
+
+.game-over__score {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #bcd6ff;
+}
+
+.retry-button {
+  appearance: none;
+  border: none;
+  background: linear-gradient(135deg, #4db5ff, #2563eb);
+  color: #f8fbff;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 1rem 2.5rem rgba(37, 99, 235, 0.45);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.retry-button:focus-visible {
+  outline: 3px solid rgba(77, 181, 255, 0.75);
+  outline-offset: 4px;
+}
+
+.retry-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 1.2rem 2.75rem rgba(37, 99, 235, 0.5);
 }
 
 .info-panel {
@@ -70,5 +119,9 @@ ul {
 
   .info-panel {
     align-items: center;
+  }
+
+  .game-panel {
+    order: -1;
   }
 }


### PR DESCRIPTION
## Summary
- enlarge the Simple Mover canvas and refresh the layout styling for a larger playfield
- add a game-over overlay that shows the final score and offers a retry button
- reset the game state when retrying so players can jump back in immediately

## Testing
- manual playtest in browser


------
https://chatgpt.com/codex/tasks/task_e_68d918fbb57c832ca22c90d8ff4e467b