### PR TITLE
Allow restarting simple mover with any key

### DIFF
--- a/simple_mover/script.js
+++ b/simple_mover/script.js
@@ -236,8 +236,29 @@ function init() {
 }
 
 window.addEventListener("keydown", (event) => {
+  const isMovementKey = [
+    "ArrowUp",
+    "ArrowDown",
+    "ArrowLeft",
+    "ArrowRight",
+    " ",
+    "w",
+    "a",
+    "s",
+    "d",
+  ].includes(event.key);
+
+  if (!gameOverOverlay.hidden) {
+    resetGame();
+  }
+
+  if (!state.playing) {
+    return;
+  }
+
   state.keys.add(event.key);
-  if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", " ", "w", "a", "s", "d"].includes(event.key)) {
+
+  if (isMovementKey) {
     event.preventDefault();
   }
 });


### PR DESCRIPTION
## Summary
- allow players to dismiss the game over overlay with any key press
- prevent the overlay from blocking play by restarting the game loop when hidden via keyboard input

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d91e3a22d8832c9579c61cf0db20ba