### PR TITLE
Add arcade-styled Connect Four with AI opponent

### DIFF
--- a/connect-four/index.html
+++ b/connect-four/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Arcade Connect Four</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Roboto:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="game-shell">
+      <header class="game-header">
+        <h1>Arcade Connect Four</h1>
+        <p class="subtitle">Drop the discs, line up four, and outsmart the arcade AI.</p>
+      </header>
+      <main class="game-area">
+        <section class="status-panel">
+          <p id="status" class="status-text">Your turn! Tap or click a column to drop a disc.</p>
+        </section>
+        <section class="board-wrapper">
+          <div id="board" class="board" aria-label="Connect Four board" role="grid"></div>
+        </section>
+        <section class="controls">
+          <button id="resetBtn" class="reset-btn" type="button" aria-label="Reset game">
+            Reset Game
+          </button>
+        </section>
+      </main>
+    </div>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/connect-four/script.js
+++ b/connect-four/script.js
@@ -1,0 +1,487 @@
+const ROWS = 6;
+const COLS = 7;
+const HUMAN = 1;
+const AI = 2;
+const MAX_DEPTH = 4;
+
+const boardEl = document.getElementById('board');
+const statusEl = document.getElementById('status');
+const resetBtn = document.getElementById('resetBtn');
+
+let boardState = [];
+let cellMatrix = [];
+let gameActive = true;
+let allowInput = true;
+let currentPlayer = HUMAN;
+let previewDisc;
+
+function init() {
+  buildBoard();
+  attachListeners();
+  resetGame();
+}
+
+function buildBoard() {
+  boardEl.replaceChildren();
+  boardEl.style.setProperty('--cols', COLS);
+  boardEl.style.setProperty('--rows', ROWS);
+
+  cellMatrix = Array.from({ length: ROWS }, () => Array(COLS));
+
+  for (let row = 0; row < ROWS; row += 1) {
+    for (let col = 0; col < COLS; col += 1) {
+      const cell = document.createElement('div');
+      cell.className = 'cell';
+      cell.dataset.row = String(row);
+      cell.dataset.col = String(col);
+      cell.setAttribute('role', 'gridcell');
+      cell.setAttribute('aria-label', `Row ${row + 1}, column ${col + 1}`);
+      cellMatrix[row][col] = cell;
+      boardEl.appendChild(cell);
+    }
+  }
+
+  previewDisc = document.createElement('div');
+  previewDisc.className = 'preview-disc';
+  boardEl.appendChild(previewDisc);
+}
+
+function attachListeners() {
+  boardEl.addEventListener('pointermove', handlePointerMove);
+  boardEl.addEventListener('pointerleave', hidePreview);
+  boardEl.addEventListener('pointerdown', handlePointerDown);
+  resetBtn.addEventListener('click', resetGame);
+}
+
+function resetGame() {
+  boardState = Array.from({ length: ROWS }, () => Array(COLS).fill(0));
+  gameActive = true;
+  allowInput = true;
+  currentPlayer = HUMAN;
+  updateStatus('Your turn! Tap or click a column to drop a disc.');
+  boardEl.classList.remove('disabled');
+  hidePreview();
+  previewDisc?.classList.remove('ai-turn');
+
+  for (let row = 0; row < ROWS; row += 1) {
+    for (let col = 0; col < COLS; col += 1) {
+      const cell = cellMatrix[row][col];
+      if (!cell) continue;
+      const disc = cell.querySelector('.disc');
+      if (disc) {
+        disc.remove();
+      }
+    }
+  }
+}
+
+function handlePointerMove(event) {
+  if (!gameActive || !allowInput) {
+    hidePreview();
+    return;
+  }
+  const cell = event.target.closest('.cell');
+  if (!cell) {
+    hidePreview();
+    return;
+  }
+
+  const col = Number(cell.dataset.col);
+  if (Number.isNaN(col) || getAvailableRow(boardState, col) === -1) {
+    hidePreview();
+    return;
+  }
+
+  showPreview(col);
+}
+
+function handlePointerDown(event) {
+  if (event.button !== undefined && event.button !== 0) {
+    return;
+  }
+  const cell = event.target.closest('.cell');
+  if (!cell) return;
+  const col = Number(cell.dataset.col);
+  if (Number.isNaN(col)) return;
+  handlePlayerMove(col);
+}
+
+async function handlePlayerMove(col) {
+  if (!gameActive || !allowInput) return;
+
+  const availableRow = getAvailableRow(boardState, col);
+  if (availableRow === -1) {
+    return;
+  }
+
+  allowInput = false;
+  hidePreview();
+  const { disc } = dropDisc(availableRow, col, HUMAN);
+  await waitForAnimation(disc);
+
+  if (checkWin(boardState, HUMAN)) {
+    finishGame('You connected four! Victory!');
+    return;
+  }
+
+  if (isBoardFull(boardState)) {
+    finishGame("Stalemate! It's a draw.");
+    return;
+  }
+
+  currentPlayer = AI;
+  previewDisc.classList.add('ai-turn');
+  updateStatus('Arcade AI is thinking...');
+  await pause(280);
+  await performAiMove();
+}
+
+async function performAiMove() {
+  if (!gameActive) return;
+  const aiColumn = chooseAiColumn(boardState);
+  if (aiColumn === null) {
+    finishGame("Stalemate! It's a draw.");
+    return;
+  }
+  const row = getAvailableRow(boardState, aiColumn);
+  if (row === -1) {
+    finishGame("Stalemate! It's a draw.");
+    return;
+  }
+
+  const { disc } = dropDisc(row, aiColumn, AI);
+  await waitForAnimation(disc);
+
+  if (checkWin(boardState, AI)) {
+    finishGame('Arcade AI lines up four. Better luck next time!');
+    return;
+  }
+
+  if (isBoardFull(boardState)) {
+    finishGame("Stalemate! It's a draw.");
+    return;
+  }
+
+  currentPlayer = HUMAN;
+  previewDisc.classList.remove('ai-turn');
+  allowInput = true;
+  updateStatus('Your turn! Drop another disc.');
+}
+
+function dropDisc(row, col, player) {
+  boardState[row][col] = player;
+  const cell = cellMatrix[row][col];
+  const disc = document.createElement('div');
+  disc.className = `disc ${player === HUMAN ? 'player-disc' : 'ai-disc'}`;
+  disc.style.setProperty('--row-index', row);
+  cell.appendChild(disc);
+  return { row, disc };
+}
+
+function waitForAnimation(element) {
+  return new Promise((resolve) => {
+    if (!element) {
+      resolve();
+      return;
+    }
+    element.addEventListener(
+      'animationend',
+      () => {
+        resolve();
+      },
+      { once: true }
+    );
+  });
+}
+
+function pause(duration) {
+  return new Promise((resolve) => setTimeout(resolve, duration));
+}
+
+function finishGame(message) {
+  gameActive = false;
+  allowInput = false;
+  updateStatus(message);
+  boardEl.classList.add('disabled');
+  hidePreview();
+}
+
+function showPreview(col) {
+  if (!previewDisc) return;
+  const targetCell = cellMatrix[0][col];
+  if (!targetCell) return;
+  const boardRect = boardEl.getBoundingClientRect();
+  const cellRect = targetCell.getBoundingClientRect();
+  const offsetX = cellRect.left - boardRect.left;
+  previewDisc.style.setProperty('--preview-x', `${offsetX}px`);
+  previewDisc.classList.toggle('ai-turn', currentPlayer === AI);
+  previewDisc.classList.add('visible');
+}
+
+function hidePreview() {
+  previewDisc?.classList.remove('visible');
+}
+
+function updateStatus(message) {
+  statusEl.textContent = message;
+}
+
+function getAvailableRow(state, col) {
+  for (let row = ROWS - 1; row >= 0; row -= 1) {
+    if (state[row][col] === 0) {
+      return row;
+    }
+  }
+  return -1;
+}
+
+function isBoardFull(state) {
+  return state.every((row) => row.every((cell) => cell !== 0));
+}
+
+function checkWin(state, player) {
+  // Horizontal
+  for (let row = 0; row < ROWS; row += 1) {
+    for (let col = 0; col <= COLS - 4; col += 1) {
+      if (
+        state[row][col] === player &&
+        state[row][col + 1] === player &&
+        state[row][col + 2] === player &&
+        state[row][col + 3] === player
+      ) {
+        return true;
+      }
+    }
+  }
+
+  // Vertical
+  for (let col = 0; col < COLS; col += 1) {
+    for (let row = 0; row <= ROWS - 4; row += 1) {
+      if (
+        state[row][col] === player &&
+        state[row + 1][col] === player &&
+        state[row + 2][col] === player &&
+        state[row + 3][col] === player
+      ) {
+        return true;
+      }
+    }
+  }
+
+  // Diagonal (\)
+  for (let row = 0; row <= ROWS - 4; row += 1) {
+    for (let col = 0; col <= COLS - 4; col += 1) {
+      if (
+        state[row][col] === player &&
+        state[row + 1][col + 1] === player &&
+        state[row + 2][col + 2] === player &&
+        state[row + 3][col + 3] === player
+      ) {
+        return true;
+      }
+    }
+  }
+
+  // Diagonal (/)
+  for (let row = 3; row < ROWS; row += 1) {
+    for (let col = 0; col <= COLS - 4; col += 1) {
+      if (
+        state[row][col] === player &&
+        state[row - 1][col + 1] === player &&
+        state[row - 2][col + 2] === player &&
+        state[row - 3][col + 3] === player
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function chooseAiColumn(state) {
+  const validColumns = getValidColumns(state);
+  if (validColumns.length === 0) {
+    return null;
+  }
+  const stateCopy = cloneBoard(state);
+  const { column } = minimax(stateCopy, MAX_DEPTH, -Infinity, Infinity, true);
+  if (column !== null && validColumns.includes(column)) {
+    return column;
+  }
+  // Fallback in case minimax returns null
+  return validColumns[Math.floor(Math.random() * validColumns.length)];
+}
+
+function cloneBoard(state) {
+  return state.map((row) => row.slice());
+}
+
+function getValidColumns(state) {
+  const columns = [];
+  for (let col = 0; col < COLS; col += 1) {
+    if (state[0][col] === 0) {
+      columns.push(col);
+    }
+  }
+  return columns;
+}
+
+function minimax(state, depth, alpha, beta, maximizingPlayer) {
+  const validColumns = getValidColumns(state);
+  const terminal =
+    checkWin(state, AI) || checkWin(state, HUMAN) || validColumns.length === 0;
+
+  if (depth === 0 || terminal) {
+    if (terminal) {
+      if (checkWin(state, AI)) {
+        return { column: null, score: 1000000 + depth };
+      }
+      if (checkWin(state, HUMAN)) {
+        return { column: null, score: -1000000 - depth };
+      }
+      return { column: null, score: 0 };
+    }
+    return { column: null, score: scorePosition(state, AI) };
+  }
+
+  let bestColumn = validColumns[Math.floor(Math.random() * validColumns.length)] ?? null;
+
+  if (maximizingPlayer) {
+    let value = -Infinity;
+    for (const col of shuffle(validColumns)) {
+      const tempBoard = cloneBoard(state);
+      const row = getAvailableRow(tempBoard, col);
+      if (row === -1) continue;
+      tempBoard[row][col] = AI;
+      const { score } = minimax(tempBoard, depth - 1, alpha, beta, false);
+      if (score > value) {
+        value = score;
+        bestColumn = col;
+      }
+      alpha = Math.max(alpha, value);
+      if (alpha >= beta) {
+        break;
+      }
+    }
+    return { column: bestColumn, score: value };
+  }
+
+  let value = Infinity;
+  for (const col of shuffle(validColumns)) {
+    const tempBoard = cloneBoard(state);
+    const row = getAvailableRow(tempBoard, col);
+    if (row === -1) continue;
+    tempBoard[row][col] = HUMAN;
+    const { score } = minimax(tempBoard, depth - 1, alpha, beta, true);
+    if (score < value) {
+      value = score;
+      bestColumn = col;
+    }
+    beta = Math.min(beta, value);
+    if (alpha >= beta) {
+      break;
+    }
+  }
+  return { column: bestColumn, score: value };
+}
+
+function scorePosition(state, player) {
+  let score = 0;
+  const opponent = player === HUMAN ? AI : HUMAN;
+  const centerIndex = Math.floor(COLS / 2);
+  const centerArray = [];
+  for (let row = 0; row < ROWS; row += 1) {
+    centerArray.push(state[row][centerIndex]);
+  }
+  const centerCount = centerArray.filter((value) => value === player).length;
+  score += centerCount * 30;
+
+  // Horizontal
+  for (let row = 0; row < ROWS; row += 1) {
+    for (let col = 0; col <= COLS - 4; col += 1) {
+      const windowSlice = [
+        state[row][col],
+        state[row][col + 1],
+        state[row][col + 2],
+        state[row][col + 3],
+      ];
+      score += evaluateWindow(windowSlice, player, opponent);
+    }
+  }
+
+  // Vertical
+  for (let col = 0; col < COLS; col += 1) {
+    for (let row = 0; row <= ROWS - 4; row += 1) {
+      const windowSlice = [
+        state[row][col],
+        state[row + 1][col],
+        state[row + 2][col],
+        state[row + 3][col],
+      ];
+      score += evaluateWindow(windowSlice, player, opponent);
+    }
+  }
+
+  // Positive Diagonals
+  for (let row = 0; row <= ROWS - 4; row += 1) {
+    for (let col = 0; col <= COLS - 4; col += 1) {
+      const windowSlice = [
+        state[row][col],
+        state[row + 1][col + 1],
+        state[row + 2][col + 2],
+        state[row + 3][col + 3],
+      ];
+      score += evaluateWindow(windowSlice, player, opponent);
+    }
+  }
+
+  // Negative Diagonals
+  for (let row = 3; row < ROWS; row += 1) {
+    for (let col = 0; col <= COLS - 4; col += 1) {
+      const windowSlice = [
+        state[row][col],
+        state[row - 1][col + 1],
+        state[row - 2][col + 2],
+        state[row - 3][col + 3],
+      ];
+      score += evaluateWindow(windowSlice, player, opponent);
+    }
+  }
+
+  return score;
+}
+
+function evaluateWindow(windowSlice, player, opponent) {
+  let score = 0;
+  const playerCount = windowSlice.filter((value) => value === player).length;
+  const opponentCount = windowSlice.filter((value) => value === opponent).length;
+  const emptyCount = windowSlice.filter((value) => value === 0).length;
+
+  if (playerCount === 4) {
+    score += 10000;
+  } else if (playerCount === 3 && emptyCount === 1) {
+    score += 120;
+  } else if (playerCount === 2 && emptyCount === 2) {
+    score += 12;
+  }
+
+  if (opponentCount === 3 && emptyCount === 1) {
+    score -= 140;
+  } else if (opponentCount === 2 && emptyCount === 2) {
+    score -= 16;
+  }
+
+  return score;
+}
+
+function shuffle(array) {
+  const clone = array.slice();
+  for (let i = clone.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [clone[i], clone[j]] = [clone[j], clone[i]];
+  }
+  return clone;
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/connect-four/style.css
+++ b/connect-four/style.css
@@ -1,0 +1,234 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  --background: radial-gradient(circle at top, #102449, #050914 60%);
+  --arcade-border: linear-gradient(135deg, #25e0ff, #6748ff 55%, #fe61ff);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 2vw, 3rem);
+  background: var(--background);
+  color: #f4f7ff;
+}
+
+.game-shell {
+  width: min(90vw, 960px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  background: rgba(6, 10, 25, 0.75);
+  border-radius: 28px;
+  border: 3px solid transparent;
+  background-image: linear-gradient(rgba(8, 12, 32, 0.9), rgba(8, 12, 32, 0.9)),
+    var(--arcade-border);
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55), inset 0 0 40px rgba(111, 78, 255, 0.25);
+  padding: clamp(1.25rem, 2vw, 2rem);
+}
+
+.game-header {
+  text-align: center;
+}
+
+.game-header h1 {
+  margin: 0 0 0.5rem;
+  font-family: 'Press Start 2P', cursive;
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  letter-spacing: 0.12rem;
+  color: #48f8ff;
+  text-shadow: 0 0 8px rgba(72, 248, 255, 0.75), 0 0 22px rgba(89, 120, 255, 0.6);
+}
+
+.subtitle {
+  margin: 0;
+  font-size: clamp(0.9rem, 1.8vw, 1.1rem);
+  color: rgba(216, 228, 255, 0.85);
+}
+
+.game-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.status-panel {
+  padding: 0.75rem 1.25rem;
+  background: rgba(20, 34, 68, 0.65);
+  border-radius: 16px;
+  box-shadow: inset 0 0 12px rgba(39, 93, 255, 0.35);
+}
+
+.status-text {
+  margin: 0;
+  font-weight: 500;
+  text-align: center;
+  line-height: 1.45;
+}
+
+.board-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.board {
+  --cell-size: clamp(64px, 10vw, 86px);
+  --gap: clamp(8px, 1.6vw, 14px);
+  display: grid;
+  grid-template-columns: repeat(var(--cols, 7), var(--cell-size));
+  grid-template-rows: repeat(var(--rows, 6), var(--cell-size));
+  gap: var(--gap);
+  padding: calc(var(--gap) * 1.25);
+  border-radius: 32px;
+  background:
+    radial-gradient(circle at 20% -10%, rgba(255, 255, 255, 0.25), transparent 65%),
+    radial-gradient(circle at 80% 120%, rgba(28, 250, 255, 0.25), transparent 55%),
+    linear-gradient(145deg, #1a3bb9, #112772 65%, #0a1742);
+  box-shadow: inset 0 0 30px rgba(5, 15, 45, 0.8), 0 18px 45px rgba(0, 0, 0, 0.45);
+  position: relative;
+  cursor: pointer;
+  touch-action: manipulation;
+  user-select: none;
+}
+
+.board::after {
+  content: '';
+  position: absolute;
+  inset: 6px;
+  border-radius: 28px;
+  pointer-events: none;
+  border: 2px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 14px rgba(0, 0, 0, 0.45);
+}
+
+.cell {
+  position: relative;
+  width: var(--cell-size);
+  height: var(--cell-size);
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0.8));
+  box-shadow: inset 0 8px 18px rgba(4, 8, 24, 0.9), inset 0 -6px 12px rgba(10, 20, 50, 0.9);
+  overflow: hidden;
+}
+
+.cell::after {
+  content: '';
+  position: absolute;
+  inset: 16%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 32% 30%, rgba(7, 16, 48, 0.85), rgba(0, 0, 0, 0.95));
+  box-shadow: inset 0 2px 12px rgba(0, 0, 0, 0.6);
+}
+
+.disc {
+  --row-index: 0;
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  display: block;
+  transform: translateY(calc(-1 * (var(--row-index) + 1) * (var(--cell-size) + var(--gap))));
+  animation: drop 420ms cubic-bezier(0.15, 0.8, 0.35, 1.15) forwards;
+  box-shadow: inset 0 6px 16px rgba(255, 255, 255, 0.35), inset 0 -10px 18px rgba(0, 0, 0, 0.55),
+    0 12px 28px rgba(0, 0, 0, 0.45);
+}
+
+.disc.player-disc {
+  background: radial-gradient(circle at 30% 25%, #ffbfbf, #ff4f60 55%, #c8172d 75%);
+  border: 3px solid rgba(255, 158, 162, 0.5);
+}
+
+.disc.ai-disc {
+  background: radial-gradient(circle at 30% 25%, #fff7c1, #ffd43b 55%, #ff8c00 75%);
+  border: 3px solid rgba(255, 236, 167, 0.5);
+}
+
+.preview-disc {
+  position: absolute;
+  width: var(--cell-size);
+  height: var(--cell-size);
+  border-radius: 50%;
+  top: calc(var(--gap) * 0.2);
+  left: calc(var(--gap) * 0.8);
+  background: radial-gradient(circle at 30% 25%, rgba(255, 198, 205, 0.85), rgba(255, 79, 96, 0.65));
+  box-shadow: inset 0 6px 12px rgba(255, 255, 255, 0.45), inset 0 -10px 18px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  transform: translate3d(0, -110%, 0);
+  transition: opacity 150ms ease, transform 150ms ease;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.preview-disc.visible {
+  opacity: 0.9;
+  transform: translate3d(var(--preview-x, 0), -110%, 0);
+}
+
+.preview-disc.ai-turn {
+  background: radial-gradient(circle at 30% 25%, rgba(255, 247, 193, 0.85), rgba(255, 212, 59, 0.7));
+}
+
+.board.disabled {
+  cursor: not-allowed;
+  opacity: 0.8;
+}
+
+.reset-btn {
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  border: 2px solid transparent;
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  color: #0b1026;
+  background-image: linear-gradient(135deg, #ffea5c, #ff61a6);
+  box-shadow: 0 12px 30px rgba(255, 97, 166, 0.35), inset 0 2px 6px rgba(255, 255, 255, 0.45);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  cursor: pointer;
+}
+
+.reset-btn:focus-visible {
+  outline: 3px solid #60f0ff;
+  outline-offset: 4px;
+}
+
+.reset-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(255, 97, 166, 0.45), inset 0 4px 10px rgba(255, 255, 255, 0.5);
+}
+
+.reset-btn:active {
+  transform: translateY(1px) scale(0.99);
+  box-shadow: 0 10px 22px rgba(255, 97, 166, 0.4);
+}
+
+@keyframes drop {
+  to {
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 640px) {
+  .status-panel {
+    width: 100%;
+  }
+
+  .status-text {
+    font-size: 0.95rem;
+  }
+
+  .reset-btn {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new Connect Four page with arcade-themed layout and controls
- implement disc dropping animations, win/draw handling, and a minimax-based AI opponent
- style the board, discs, and hover preview with glossy effects and responsive behavior

## Testing
- Manual testing in browser

------
https://chatgpt.com/codex/tasks/task_e_68d92091f304832c9a76dac71df4fd18