### PR TITLE
Add Online Hustle Simulator incremental game

### DIFF
--- a/online-hustle-simulator/index.html
+++ b/online-hustle-simulator/index.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Online Hustle Simulator</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="app">
+    <header class="top-bar">
+      <div class="stat">
+        <span class="label">Money</span>
+        <span id="money" class="value">$0</span>
+      </div>
+      <div class="stat time">
+        <span class="label">Time Left</span>
+        <div class="time-wrapper">
+          <span id="time" class="value">14h</span>
+          <div class="time-bar">
+            <div id="time-progress" class="time-progress"></div>
+          </div>
+        </div>
+      </div>
+      <div class="stat">
+        <span class="label">Day</span>
+        <span id="day" class="value">1</span>
+      </div>
+      <button id="end-day" class="end-day">End Day</button>
+    </header>
+
+    <main>
+      <section class="panel hustles">
+        <div class="panel-header">
+          <h2>Daily Hustles</h2>
+          <p>Spend your time wisely. When the clock hits zero, the grind resets.</p>
+        </div>
+        <div class="card-grid">
+          <article class="card" id="freelance-card">
+            <div class="card-header">
+              <h3>Freelance Writing</h3>
+              <span class="tag instant">Instant</span>
+            </div>
+            <p>Crank out a quick article for a client. Not Pulitzer material, but it pays.</p>
+            <ul class="details">
+              <li>⏳ Time: <strong>2h</strong></li>
+              <li>💵 Payout: <strong>$18</strong></li>
+            </ul>
+            <button class="primary" id="freelance-btn">Write Now</button>
+          </article>
+
+          <article class="card" id="blog-card">
+            <div class="card-header">
+              <h3>Personal Blog</h3>
+              <span class="tag passive">Passive</span>
+            </div>
+            <p>Launch a blog that trickles income while you sip questionable coffee.</p>
+            <ul class="details">
+              <li>⏳ Setup Time: <strong>3h</strong></li>
+              <li>💵 Setup Cost: <strong>$25</strong></li>
+              <li>💸 Income: <strong id="blog-income-rate">$3 / 10s</strong></li>
+            </ul>
+            <button class="primary" id="blog-btn">Launch Blog</button>
+          </article>
+
+          <article class="card" id="flip-card">
+            <div class="card-header">
+              <h3>eBay Flips</h3>
+              <span class="tag delayed">Delayed</span>
+            </div>
+            <p>Hunt for deals, flip them online. Profit arrives fashionably late.</p>
+            <ul class="details">
+              <li>⏳ Time: <strong>4h</strong></li>
+              <li>💵 Cost: <strong>$20</strong></li>
+              <li>💰 Payout: <strong>$48 after 30s</strong></li>
+            </ul>
+            <button class="primary" id="flip-btn">Start Flip</button>
+            <div class="pending" id="flip-status">No flips in progress.</div>
+          </article>
+        </div>
+      </section>
+
+      <section class="panel upgrades">
+        <div class="panel-header">
+          <h2>Upgrades & Boosts</h2>
+          <p>Invest in yourself to push the grind further.</p>
+        </div>
+        <div class="card-grid">
+          <article class="card" id="assistant-card">
+            <div class="card-header">
+              <h3>Hire Virtual Assistant</h3>
+              <span class="tag unlock">Unlock</span>
+            </div>
+            <p>Add <strong>+2h</strong> to your daily grind. They handle the boring stuff.</p>
+            <ul class="details">
+              <li>💵 Cost: <strong>$180</strong></li>
+            </ul>
+            <button class="secondary" id="assistant-btn">Hire Assistant</button>
+          </article>
+
+          <article class="card" id="coffee-card">
+            <div class="card-header">
+              <h3>Turbo Coffee</h3>
+              <span class="tag boost">Boost</span>
+            </div>
+            <p>Instantly gain <strong>+1h</strong> of focus for today. Side effects include jittery success.</p>
+            <ul class="details">
+              <li>💵 Cost: <strong>$40</strong></li>
+            </ul>
+            <button class="secondary" id="coffee-btn">Brew Boost</button>
+          </article>
+
+          <article class="card locked" id="course-card">
+            <div class="card-header">
+              <h3>Automation Course</h3>
+              <span class="tag unlock">Unlock</span>
+            </div>
+            <p>Unlocks smarter blogging tools, boosting passive income by <strong>+50%</strong>.</p>
+            <ul class="details">
+              <li>💵 Cost: <strong>$260</strong></li>
+              <li>Requires active blog</li>
+            </ul>
+            <button class="secondary" id="course-btn">Study Up</button>
+          </article>
+        </div>
+      </section>
+
+      <section class="panel log">
+        <div class="panel-header">
+          <h2>Event Log</h2>
+          <p id="log-tip">Welcome! Start hustling to fill your feed.</p>
+        </div>
+        <div id="log-feed" class="log-feed"></div>
+      </section>
+    </main>
+  </div>
+
+  <template id="log-template">
+    <div class="log-entry">
+      <span class="timestamp"></span>
+      <p class="message"></p>
+    </div>
+  </template>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/online-hustle-simulator/script.js
+++ b/online-hustle-simulator/script.js
@@ -1,0 +1,422 @@
+const STORAGE_KEY = 'online-hustle-sim-v1';
+const MAX_LOG_ENTRIES = 60;
+const BLOG_CHUNK = 3; // dollars per payout cycle
+const BLOG_INTERVAL_SECONDS = 10;
+
+const DEFAULT_STATE = {
+  money: 45,
+  timeLeft: 14,
+  baseTime: 14,
+  bonusTime: 0,
+  dailyBonusTime: 0,
+  day: 1,
+  blog: {
+    active: false,
+    multiplier: 1,
+    buffer: 0
+  },
+  pendingFlips: [],
+  assistantHired: false,
+  coffeesToday: 0,
+  coursePurchased: false,
+  log: [],
+  lastSaved: Date.now()
+};
+
+let state = structuredClone(DEFAULT_STATE);
+let lastTick = Date.now();
+
+const moneyEl = document.getElementById('money');
+const timeEl = document.getElementById('time');
+const timeProgressEl = document.getElementById('time-progress');
+const dayEl = document.getElementById('day');
+const logFeed = document.getElementById('log-feed');
+const logTemplate = document.getElementById('log-template');
+const logTip = document.getElementById('log-tip');
+
+const freelanceBtn = document.getElementById('freelance-btn');
+const blogBtn = document.getElementById('blog-btn');
+const flipBtn = document.getElementById('flip-btn');
+const flipStatus = document.getElementById('flip-status');
+const endDayBtn = document.getElementById('end-day');
+const assistantBtn = document.getElementById('assistant-btn');
+const assistantCard = document.getElementById('assistant-card');
+const coffeeBtn = document.getElementById('coffee-btn');
+const courseBtn = document.getElementById('course-btn');
+const courseCard = document.getElementById('course-card');
+const blogIncomeRateEl = document.getElementById('blog-income-rate');
+
+function structuredClone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+function createId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const saved = JSON.parse(raw);
+      state = {
+        ...structuredClone(DEFAULT_STATE),
+        ...saved,
+        blog: {
+          ...structuredClone(DEFAULT_STATE.blog),
+          ...saved.blog
+        },
+        pendingFlips: saved.pendingFlips || [],
+        log: saved.log || []
+      };
+      handleOfflineProgress(saved.lastSaved || Date.now());
+      addLog('Welcome back! Your hustles kept buzzing while you were away.', 'info');
+    } else {
+      state = structuredClone(DEFAULT_STATE);
+      addLog('Welcome to Online Hustle Simulator! Time to make that side cash.', 'info');
+    }
+  } catch (err) {
+    console.error('Failed to load state', err);
+    state = structuredClone(DEFAULT_STATE);
+  }
+  lastTick = Date.now();
+  renderLog();
+}
+
+function saveState() {
+  state.lastSaved = Date.now();
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (err) {
+    console.error('Failed to save game', err);
+  }
+}
+
+function handleOfflineProgress(lastSaved) {
+  const now = Date.now();
+  const elapsed = Math.max(0, (now - lastSaved) / 1000);
+  if (!elapsed) return;
+
+  if (state.blog.active) {
+    const offlineMoney = collectBlogIncome(elapsed, true);
+    if (offlineMoney > 0) {
+      addLog(`Your blog earned $${formatMoney(offlineMoney)} while you were offline. Not too shabby!`, 'passive');
+    }
+  }
+
+  if (state.pendingFlips.length) {
+    processFlips(now, true);
+  }
+}
+
+function getTimeCap() {
+  return state.baseTime + state.bonusTime + state.dailyBonusTime;
+}
+
+function formatMoney(value) {
+  return Number(value).toLocaleString(undefined, {
+    minimumFractionDigits: value % 1 === 0 ? 0 : 2,
+    maximumFractionDigits: 2
+  });
+}
+
+function formatHours(hours) {
+  if (Math.abs(hours - Math.round(hours)) < 0.05) {
+    return `${Math.round(hours)}h`;
+  }
+  return `${hours.toFixed(1)}h`;
+}
+
+function addMoney(amount, message, type = 'info') {
+  state.money = Math.max(0, Number(state.money) + Number(amount));
+  flashValue(moneyEl);
+  if (message) {
+    addLog(message, type);
+  }
+}
+
+function spendMoney(amount) {
+  state.money = Math.max(0, state.money - amount);
+  flashValue(moneyEl, true);
+}
+
+function flashValue(el, negative = false) {
+  const className = negative ? 'flash-negative' : 'flash';
+  el.classList.remove('flash', 'flash-negative');
+  void el.offsetWidth;
+  el.classList.add(className);
+  setTimeout(() => el.classList.remove(className), 500);
+}
+
+function addLog(message, type = 'info') {
+  const entry = {
+    id: createId(),
+    timestamp: Date.now(),
+    message,
+    type
+  };
+  state.log.push(entry);
+  if (state.log.length > MAX_LOG_ENTRIES) {
+    state.log.splice(0, state.log.length - MAX_LOG_ENTRIES);
+  }
+  renderLog();
+}
+
+function renderLog() {
+  if (!state.log.length) {
+    logTip.style.display = 'block';
+    logFeed.innerHTML = '';
+    return;
+  }
+  logTip.style.display = 'none';
+  logFeed.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+  const entries = [...state.log].sort((a, b) => b.timestamp - a.timestamp);
+  for (const item of entries) {
+    const node = logTemplate.content.cloneNode(true);
+    const entryEl = node.querySelector('.log-entry');
+    entryEl.classList.add(`type-${item.type}`);
+    node.querySelector('.timestamp').textContent = new Date(item.timestamp).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+    node.querySelector('.message').textContent = item.message;
+    fragment.appendChild(node);
+  }
+  logFeed.appendChild(fragment);
+  logFeed.scrollTop = 0;
+}
+
+function updateUI() {
+  moneyEl.textContent = `$${formatMoney(state.money)}`;
+  timeEl.textContent = `${formatHours(state.timeLeft)} / ${formatHours(getTimeCap())}`;
+  dayEl.textContent = state.day;
+
+  const cap = getTimeCap();
+  const percent = cap === 0 ? 0 : Math.min(100, Math.max(0, (state.timeLeft / cap) * 100));
+  timeProgressEl.style.width = `${percent}%`;
+
+  freelanceBtn.disabled = state.timeLeft < 2;
+  blogBtn.disabled = state.blog.active || state.timeLeft < 3 || state.money < 25;
+  flipBtn.disabled = state.timeLeft < 4 || state.money < 20;
+
+  assistantBtn.disabled = state.assistantHired || state.money < 180;
+  assistantBtn.textContent = state.assistantHired ? 'Assistant Hired' : 'Hire Assistant';
+  assistantCard.classList.toggle('locked', state.assistantHired);
+
+  const coffeeLimit = 3;
+  coffeeBtn.disabled = state.money < 40 || state.coffeesToday >= coffeeLimit || state.timeLeft <= 0;
+  coffeeBtn.textContent = state.coffeesToday >= coffeeLimit ? 'Too Much Caffeine' : 'Brew Boost';
+
+  const blogReadyForCourse = state.blog.active;
+  const courseLocked = !blogReadyForCourse || state.coursePurchased;
+  courseCard.classList.toggle('locked', !blogReadyForCourse && !state.coursePurchased);
+  courseBtn.disabled = courseLocked || state.money < 260;
+  if (state.coursePurchased) {
+    courseBtn.textContent = 'Automation Ready';
+  } else if (!blogReadyForCourse) {
+    courseBtn.textContent = 'Requires Active Blog';
+  } else {
+    courseBtn.textContent = 'Study Up';
+  }
+
+  blogBtn.textContent = state.blog.active ? 'Blog Running' : 'Launch Blog';
+  if (blogIncomeRateEl) {
+    const income = BLOG_CHUNK * state.blog.multiplier;
+    blogIncomeRateEl.textContent = `$${formatMoney(income)} / 10s`;
+  }
+
+  updateFlipStatus();
+}
+
+function updateFlipStatus() {
+  if (!state.pendingFlips.length) {
+    flipStatus.textContent = 'No flips in progress.';
+    return;
+  }
+  const now = Date.now();
+  const nextFlip = state.pendingFlips.reduce((soonest, flip) =>
+    flip.readyAt < soonest.readyAt ? flip : soonest
+  );
+  const timeRemaining = Math.max(0, Math.round((nextFlip.readyAt - now) / 1000));
+  const label = timeRemaining === 0 ? 'any moment' : `${timeRemaining}s`;
+  const descriptor = state.pendingFlips.length === 1 ? 'flip' : 'flips';
+  flipStatus.textContent = `${state.pendingFlips.length} ${descriptor} in progress. Next payout in ${label}.`;
+}
+
+function performFreelance() {
+  if (state.timeLeft < 2) return;
+  state.timeLeft -= 2;
+  addMoney(18, 'You hustled an article for $18. Not Pulitzer material, but it pays the bills!');
+  checkDayEnd();
+  updateUI();
+  saveState();
+}
+
+function launchBlog() {
+  if (state.blog.active || state.timeLeft < 3 || state.money < 25) return;
+  state.timeLeft -= 3;
+  spendMoney(25);
+  state.blog.active = true;
+  state.blog.buffer = 0;
+  addLog('You launched your blog! Expect slow trickles of internet fame and $3 every 10 seconds.', 'passive');
+  checkDayEnd();
+  updateUI();
+  saveState();
+}
+
+function startFlip() {
+  if (state.timeLeft < 4 || state.money < 20) return;
+  state.timeLeft -= 4;
+  spendMoney(20);
+  const flip = {
+    id: createId(),
+    readyAt: Date.now() + 30000,
+    payout: 48
+  };
+  state.pendingFlips.push(flip);
+  addLog('You listed a spicy eBay flip. In 30 seconds it should cha-ching for $48!', 'delayed');
+  checkDayEnd();
+  updateUI();
+  saveState();
+}
+
+function hireAssistant() {
+  if (state.assistantHired || state.money < 180) return;
+  spendMoney(180);
+  state.assistantHired = true;
+  state.bonusTime += 2;
+  state.timeLeft = Math.min(state.timeLeft + 2, getTimeCap());
+  addLog('You hired a virtual assistant who adds +2h to your day and handles inbox chaos.', 'upgrade');
+  updateUI();
+  saveState();
+}
+
+function brewCoffee() {
+  const coffeeLimit = 3;
+  if (state.money < 40 || state.coffeesToday >= coffeeLimit || state.timeLeft <= 0) return;
+  spendMoney(40);
+  state.coffeesToday += 1;
+  state.dailyBonusTime += 1;
+  state.timeLeft = Math.min(state.timeLeft + 1, getTimeCap());
+  addLog('Turbo coffee acquired! You feel invincible for another hour (ish).', 'boost');
+  updateUI();
+  saveState();
+}
+
+function purchaseCourse() {
+  if (state.coursePurchased || !state.blog.active || state.money < 260) return;
+  spendMoney(260);
+  state.coursePurchased = true;
+  state.blog.multiplier = 1.5;
+  addLog('Automation course complete! Your blog now earns +50% more while you nap.', 'upgrade');
+  updateUI();
+  saveState();
+}
+
+function endDay(auto = false) {
+  const message = auto ? 'You ran out of time. The grind resets tomorrow.' : 'You called it a day. Fresh hustle awaits tomorrow.';
+  addLog(`${message} Day ${state.day + 1} begins with renewed energy.`, 'info');
+  state.day += 1;
+  state.coffeesToday = 0;
+  state.dailyBonusTime = 0;
+  state.timeLeft = getTimeCap();
+  updateUI();
+  saveState();
+}
+
+function checkDayEnd() {
+  if (state.timeLeft <= 0) {
+    state.timeLeft = 0;
+    updateUI();
+    setTimeout(() => endDay(true), 400);
+  }
+}
+
+function collectBlogIncome(elapsedSeconds, offline = false) {
+  if (!state.blog.active) return 0;
+  const chunkValue = BLOG_CHUNK * state.blog.multiplier;
+  const ratePerSecond = chunkValue / BLOG_INTERVAL_SECONDS;
+  state.blog.buffer += ratePerSecond * elapsedSeconds;
+  let payouts = 0;
+  while (state.blog.buffer >= chunkValue) {
+    state.blog.buffer -= chunkValue;
+    payouts += chunkValue;
+    if (!offline) {
+      addMoney(chunkValue, `Your blog quietly earned $${formatMoney(chunkValue)} while you scrolled memes.`, 'passive');
+    }
+  }
+  if (offline && payouts > 0) {
+    state.money += payouts;
+  }
+  return payouts;
+}
+
+function processFlips(now = Date.now(), offline = false) {
+  const remaining = [];
+  let offlineTotal = 0;
+  let completed = 0;
+  for (const flip of state.pendingFlips) {
+    if (flip.readyAt <= now) {
+      completed += 1;
+      if (offline) {
+        state.money += flip.payout;
+        offlineTotal += flip.payout;
+      } else {
+        addMoney(flip.payout, `Your eBay flip sold for $${formatMoney(flip.payout)}! Shipping label time.`, 'delayed');
+      }
+    } else {
+      remaining.push(flip);
+    }
+  }
+  if (completed > 0 && offline) {
+    addLog(`While you were away, ${completed} eBay ${completed === 1 ? 'flip' : 'flips'} paid out. $${formatMoney(offlineTotal)} richer!`, 'delayed');
+  }
+  state.pendingFlips = remaining;
+}
+
+function gameLoop() {
+  const now = Date.now();
+  const dt = Math.min(5, (now - lastTick) / 1000);
+  lastTick = now;
+
+  if (dt <= 0) return;
+
+  if (state.blog.active) {
+    collectBlogIncome(dt, false);
+  }
+
+  if (state.pendingFlips.length) {
+    const maturedBefore = state.pendingFlips.length;
+    processFlips(now, false);
+    if (maturedBefore !== state.pendingFlips.length) {
+      updateFlipStatus();
+    }
+  }
+
+  updateUI();
+  saveState();
+}
+
+freelanceBtn.addEventListener('click', performFreelance);
+blogBtn.addEventListener('click', launchBlog);
+flipBtn.addEventListener('click', startFlip);
+assistantBtn.addEventListener('click', hireAssistant);
+coffeeBtn.addEventListener('click', brewCoffee);
+courseBtn.addEventListener('click', purchaseCourse);
+endDayBtn.addEventListener('click', () => endDay(false));
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    lastTick = Date.now();
+  }
+});
+
+window.addEventListener('beforeunload', saveState);
+
+loadState();
+updateUI();
+setInterval(gameLoop, 1000);

--- a/online-hustle-simulator/styles.css
+++ b/online-hustle-simulator/styles.css
@@ -1,0 +1,366 @@
+:root {
+  --bg: #0f172a;
+  --card-bg: rgba(15, 23, 42, 0.65);
+  --panel-bg: rgba(15, 23, 42, 0.85);
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --success: #4ade80;
+  --warning: #f97316;
+  --danger: #f87171;
+  --shadow: 0 16px 30px rgba(15, 23, 42, 0.2);
+  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at 10% 20%, #1e293b 0%, #0f172a 45%, #020617 100%);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem 3rem;
+}
+
+.app {
+  width: min(1100px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.top-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  background: var(--panel-bg);
+  backdrop-filter: blur(20px);
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  align-items: center;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.stat .label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.stat .value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--text);
+  transition: color 0.3s ease;
+}
+
+.stat .value.flash {
+  color: var(--success);
+}
+
+.stat .value.flash-negative {
+  color: var(--danger);
+}
+
+.time {
+  position: relative;
+}
+
+.time-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.time-bar {
+  width: 100%;
+  height: 8px;
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.time-progress {
+  height: 100%;
+  width: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  transition: width 0.4s ease;
+}
+
+.end-day {
+  justify-self: end;
+  padding: 0.75rem 1.2rem;
+  border-radius: 12px;
+  border: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  background: rgba(56, 189, 248, 0.1);
+  color: var(--accent);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.end-day:hover,
+.end-day:focus-visible {
+  background: rgba(56, 189, 248, 0.2);
+  transform: translateY(-2px);
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.panel-header {
+  margin-bottom: 1rem;
+}
+
+.panel-header h2 {
+  font-size: 1.6rem;
+  margin-bottom: 0.2rem;
+}
+
+.panel-header p {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 20px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-3px);
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.3);
+}
+
+.card.locked {
+  opacity: 0.6;
+}
+
+.card.locked button {
+  pointer-events: none;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.card-header h3 {
+  font-size: 1.15rem;
+}
+
+.tag {
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.tag.instant {
+  color: var(--success);
+  background: rgba(74, 222, 128, 0.12);
+}
+
+.tag.passive {
+  color: #facc15;
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.tag.delayed {
+  color: var(--accent);
+  background: rgba(14, 165, 233, 0.12);
+}
+
+.tag.unlock {
+  color: #c084fc;
+  background: rgba(192, 132, 252, 0.12);
+}
+
+.tag.boost {
+  color: var(--warning);
+  background: rgba(249, 115, 22, 0.12);
+}
+
+.details {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.primary,
+.secondary {
+  padding: 0.75rem;
+  border-radius: 12px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #0f172a;
+  box-shadow: 0 10px 20px rgba(14, 165, 233, 0.25);
+}
+
+.primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.secondary {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+}
+
+.secondary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.primary:not(:disabled):hover,
+.primary:not(:disabled):focus-visible,
+.secondary:not(:disabled):hover,
+.secondary:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+}
+
+.pending {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.log-feed {
+  display: flex;
+  flex-direction: column;
+  max-height: 280px;
+  overflow-y: auto;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+}
+
+.log-entry {
+  background: rgba(148, 163, 184, 0.08);
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  display: grid;
+  grid-template-columns: minmax(70px, auto) 1fr;
+  gap: 0.6rem;
+  align-items: center;
+  border-left: 3px solid rgba(148, 163, 184, 0.35);
+}
+
+.log-entry .timestamp {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.7);
+  text-transform: uppercase;
+}
+
+.log-entry .message {
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.log-entry.type-info {
+  border-left-color: var(--accent);
+}
+
+.log-entry.type-passive {
+  border-left-color: #facc15;
+}
+
+.log-entry.type-delayed {
+  border-left-color: var(--accent-strong);
+}
+
+.log-entry.type-upgrade {
+  border-left-color: #c084fc;
+}
+
+.log-entry.type-boost {
+  border-left-color: var(--warning);
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 1.5rem 0.75rem 2.5rem;
+  }
+
+  .top-bar {
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .panel {
+    padding: 1.25rem;
+  }
+
+  .card {
+    padding: 1rem;
+  }
+
+  .log-entry {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .top-bar {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .end-day {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new Online Hustle Simulator game with responsive UI and themed hustles
- implement core idle mechanics with day resets, passive income, delayed rewards, and upgrades
- persist player progress in localStorage with humorous event log feedback

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d9252919b0832c844652b92d793a95