### PR TITLE
Revamp arcade homepage and unify game shells

### DIFF
--- a/2048/index.html
+++ b/2048/index.html
@@ -8,68 +8,91 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <main class="app">
-      <header class="top-bar">
-        <div class="branding">
+    <div class="arcade-page">
+      <header class="arcade-header card-surface">
+        <div class="arcade-header__meta">
+          <span class="brand-title">Pixel Playground</span>
           <h1>2048</h1>
-          <p>Swipe or use your keyboard to combine matching tiles.</p>
+          <p>Swipe or use your keyboard to combine matching tiles until you hit the 2048 target.</p>
         </div>
-        <div class="scoreboard" role="status" aria-live="polite">
-          <div class="score-block">
-            <span class="label">Score</span>
-            <span id="score" class="value">0</span>
-          </div>
-          <div class="score-block">
-            <span class="label">Best</span>
-            <span id="best" class="value">0</span>
-          </div>
-          <button id="reset" type="button" class="button">New Game</button>
-        </div>
+        <a class="arcade-back" href="../index.html">
+          <span aria-hidden="true">⟵</span>
+          Back to Arcade
+        </a>
       </header>
-      <section class="board" aria-label="2048 board">
-        <div class="grid">
-          <div class="grid-row">
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
+
+      <main class="arcade-main">
+          <div class="app">
+            <header class="top-bar">
+              <div class="branding">
+                <h2>Merge the numbers</h2>
+                <p>Use arrow keys, WASD, or swipe gestures to slide tiles.</p>
+              </div>
+              <div class="scoreboard" role="status" aria-live="polite">
+                <div class="score-block">
+                  <span class="label">Score</span>
+                  <span id="score" class="value">0</span>
+                </div>
+                <div class="score-block">
+                  <span class="label">Best</span>
+                  <span id="best" class="value">0</span>
+                </div>
+                <button id="reset" type="button" class="button">New Game</button>
+              </div>
+            </header>
+
+            <section class="board" aria-label="2048 board">
+              <div class="grid">
+                <div class="grid-row">
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                </div>
+                <div class="grid-row">
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                </div>
+                <div class="grid-row">
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                </div>
+                <div class="grid-row">
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                  <div class="grid-cell"></div>
+                </div>
+              </div>
+              <div class="tile-container" aria-hidden="true"></div>
+              <div id="message" class="message" role="alert" hidden>
+                <div class="message-box">
+                  <p id="message-text"></p>
+                  <button id="keep-playing" type="button" class="button button-secondary">Keep Playing</button>
+                </div>
+              </div>
+            </section>
+
+            <footer class="info">
+              <h2>How to play</h2>
+              <ul>
+                <li><strong>Desktop:</strong> Use arrow keys or WASD to slide tiles.</li>
+                <li><strong>Touch:</strong> Swipe in any direction.</li>
+                <li>Combine tiles with the same number to reach <strong>2048</strong>.</li>
+              </ul>
+            </footer>
           </div>
-          <div class="grid-row">
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
-          </div>
-          <div class="grid-row">
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
-          </div>
-          <div class="grid-row">
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
-            <div class="grid-cell"></div>
-          </div>
-        </div>
-        <div class="tile-container" aria-hidden="true"></div>
-        <div id="message" class="message" role="alert" hidden>
-          <div class="message-box">
-            <p id="message-text"></p>
-            <button id="keep-playing" type="button" class="button button-secondary">Keep Playing</button>
-          </div>
-        </div>
-      </section>
-      <footer class="info">
-        <h2>How to play</h2>
-        <ul>
-          <li><strong>Desktop:</strong> Use arrow keys or WASD to slide tiles.</li>
-          <li><strong>Touch:</strong> Swipe in any direction.</li>
-          <li>Combine tiles with the same number to reach <strong>2048</strong>.</li>
-        </ul>
+        </main>
+
+      <footer class="arcade-footer">
+        © <span class="js-year"></span> Pixel Playground · Keep merging to chase higher scores.
       </footer>
-    </main>
+    </div>
     <script src="script.js" defer></script>
+    <script src="../assets/js/arcade.js" defer></script>
   </body>
 </html>

--- a/2048/style.css
+++ b/2048/style.css
@@ -19,8 +19,14 @@ body {
   min-height: 100vh;
   display: flex;
   justify-content: center;
+  align-items: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
   background: radial-gradient(circle at top, #f5efff 0%, #f0f4ff 45%, #f9f5ff 100%);
   color: var(--text);
+}
+
+.arcade-main {
+  align-items: center;
 }
 
 .app {
@@ -43,7 +49,7 @@ body {
   box-shadow: 0 1.25rem 3rem rgba(78, 61, 158, 0.12);
 }
 
-.branding h1 {
+.branding h2 {
   margin: 0;
   font-size: clamp(2.5rem, 6vw, 3.5rem);
   letter-spacing: 0.08em;

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Pixel Playground Arcade
+
+A collection of bite-sized JavaScript arcade games wrapped in a unified retro aesthetic. Each game is built with vanilla HTML, CSS, and JavaScript so they load instantly in the browser.
+
+## Games
+
+| Game | Genre | Description |
+| ---- | ----- | ----------- |
+| [2048](./2048/) | Swipe puzzle | Merge matching tiles until you reach the legendary 2048 block. |
+| [Flappy Bird Remix](./flappy-bird/) | Reflex | Glide through neon pipes and keep the bird aloft to earn points. |
+| [Connect Four](./connect-four/) | Tabletop duel | Challenge the arcade AI or a friend to line up four discs. |
+| [Endless Runner](./endless-runner/) | Action | Dash through synthwave streets, avoiding obstacles to extend your run. |
+| [Simple Mover](./simple_mover/) | Arcade trainer | Collect stars, dash through gaps, and dodge reactive walls. |
+| [Block Drop](./tetris_knockoff/) | Falling blocks | Rotate and stack tetrominoes to clear lines and level up. |
+
+## Running locally
+
+Because everything is static, you can open `index.html` directly in a browser. For the best experience (and to avoid CORS restrictions in some browsers) run a small HTTP server:
+
+```bash
+cd javascript_games
+python -m http.server 8000
+```
+
+Then visit [http://localhost:8000/](http://localhost:8000/) to access the arcade cabinet and launch any of the games.
+
+## Project structure
+
+```
+javascript_games/
+├── assets/             # Shared artwork and helper scripts
+│   ├── js/
+│   │   └── arcade.js   # Shared helpers (currently used for the footer year)
+│   └── thumbnails/     # Game thumbnails for the homepage grid
+├── arcade.css          # Global visual language shared by all pages
+├── index.html          # Arcade homepage listing every available game
+├── <game>/             # Individual game folders with their own HTML/CSS/JS
+└── README.md
+```
+
+Each game remains self-contained so you can modify or extend them independently while retaining the cohesive shell provided by `arcade.css`.
+
+## Contributing
+
+Pull requests are welcome! Ideas include polishing gameplay, adding accessibility improvements, creating additional themes, or submitting new mini-games that fit the retro arcade vibe.

--- a/arcade.css
+++ b/arcade.css
@@ -51,3 +51,108 @@ button,
 .text-soft {
   color: rgba(248, 249, 255, 0.72);
 }
+
+.arcade-page {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.arcade-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(1rem, 2vw, 2.5rem);
+  padding: clamp(1rem, 3vw, 1.75rem);
+  border-radius: 20px;
+  background: rgba(12, 14, 40, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 24px 60px rgba(8, 10, 28, 0.55);
+}
+
+.arcade-header__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.arcade-header__meta h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  line-height: 1.1;
+}
+
+.arcade-header__meta p {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.4vw, 1.125rem);
+  color: rgba(248, 249, 255, 0.72);
+}
+
+.arcade-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  padding: 0.65rem 1.3rem;
+  border-radius: 999px;
+  text-decoration: none;
+  background: rgba(123, 91, 255, 0.25);
+  border: 1px solid rgba(123, 91, 255, 0.45);
+  box-shadow: 0 14px 30px rgba(9, 11, 28, 0.45);
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.arcade-back span {
+  font-size: 1rem;
+}
+
+.arcade-back:hover,
+.arcade-back:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(123, 91, 255, 0.75);
+  box-shadow: 0 18px 34px rgba(9, 11, 28, 0.55);
+}
+
+.arcade-main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.arcade-footer {
+  padding: clamp(1rem, 2.4vw, 1.5rem);
+  text-align: center;
+  font-size: 0.9rem;
+  color: rgba(248, 249, 255, 0.65);
+  border-radius: 18px;
+  background: rgba(12, 14, 40, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 18px 40px rgba(6, 9, 25, 0.45);
+}
+
+.arcade-footer a {
+  color: rgba(123, 209, 255, 0.85);
+  text-decoration: none;
+}
+
+.arcade-footer a:hover,
+.arcade-footer a:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .arcade-header {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .arcade-back {
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/assets/js/arcade.js
+++ b/assets/js/arcade.js
@@ -1,0 +1,6 @@
+(() => {
+  const year = new Date().getFullYear();
+  document.querySelectorAll('.js-year').forEach((el) => {
+    el.textContent = year;
+  });
+})();

--- a/assets/thumbnails/block-drop.svg
+++ b/assets/thumbnails/block-drop.svg
@@ -1,0 +1,31 @@
+<svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradBlock" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e3a8a"/>
+      <stop offset="100%" stop-color="#9333ea"/>
+    </linearGradient>
+    <linearGradient id="piece" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#38f9d7"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+    <linearGradient id="ghost" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.65"/>
+      <stop offset="100%" stop-color="#f0abfc" stop-opacity="0.35"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="160" height="120" rx="16" fill="url(#gradBlock)"/>
+  <g transform="translate(44 20)">
+    <rect x="56" y="4" width="20" height="60" rx="4" fill="url(#ghost)"/>
+    <g fill="url(#piece)" stroke="#ecfeff" stroke-width="2">
+      <rect x="20" y="16" width="20" height="20" rx="3"/>
+      <rect x="40" y="16" width="20" height="20" rx="3"/>
+      <rect x="40" y="36" width="20" height="20" rx="3"/>
+      <rect x="60" y="36" width="20" height="20" rx="3"/>
+    </g>
+    <g fill="none" stroke="rgba(236, 254, 255, 0.35)" stroke-width="2">
+      <rect x="0" y="76" width="72" height="20" rx="4"/>
+      <rect x="24" y="96" width="72" height="20" rx="4"/>
+    </g>
+  </g>
+  <text x="24" y="104" font-family="'Poppins', sans-serif" font-weight="600" font-size="14" fill="#f8fafc">STACK &amp; CLEAR</text>
+</svg>

--- a/assets/thumbnails/simple-mover.svg
+++ b/assets/thumbnails/simple-mover.svg
@@ -1,0 +1,22 @@
+<svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradMover" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="sparkMover" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#e0f2fe" stop-opacity="0.2"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="160" height="120" rx="16" fill="url(#gradMover)"/>
+  <g fill="none" stroke="url(#sparkMover)" stroke-width="6" stroke-linecap="round">
+    <path d="M30 86 L70 46"/>
+    <path d="M70 46 L94 70"/>
+    <path d="M94 70 L130 34"/>
+  </g>
+  <circle cx="70" cy="46" r="12" fill="#f8fafc" opacity="0.85"/>
+  <circle cx="94" cy="70" r="10" fill="#e0f2fe" opacity="0.9"/>
+  <circle cx="130" cy="34" r="8" fill="#c4b5fd" opacity="0.9"/>
+  <text x="32" y="36" font-family="'Poppins', sans-serif" font-weight="600" font-size="14" fill="#e0f2fe">DASH!</text>
+</svg>

--- a/connect-four/index.html
+++ b/connect-four/index.html
@@ -3,35 +3,57 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Arcade Connect Four</title>
+    <title>Connect Four · Pixel Playground</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Roboto:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="../arcade.css" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div class="game-shell">
-      <header class="game-header">
-        <h1>Arcade Connect Four</h1>
-        <p class="subtitle">Drop the discs, line up four, and outsmart the arcade AI.</p>
+    <div class="arcade-page">
+      <header class="arcade-header card-surface">
+        <div class="arcade-header__meta">
+          <span class="brand-title">Pixel Playground</span>
+          <h1>Connect Four</h1>
+          <p>Drop discs into the neon grid and be the first to align four in a row.</p>
+        </div>
+        <a class="arcade-back" href="../index.html">
+          <span aria-hidden="true">⟵</span>
+          Back to Arcade
+        </a>
       </header>
-      <main class="game-area">
-        <section class="status-panel">
-          <p id="status" class="status-text">Your turn! Tap or click a column to drop a disc.</p>
-        </section>
-        <section class="board-wrapper">
-          <div id="board" class="board" aria-label="Connect Four board" role="grid"></div>
-        </section>
-        <section class="controls">
-          <button id="resetBtn" class="reset-btn" type="button" aria-label="Reset game">
-            Reset Game
-          </button>
-        </section>
+
+      <main class="arcade-main">
+        <div class="game-shell">
+          <header class="game-header">
+            <h2>Arcade Connect Four</h2>
+            <p class="subtitle">Drop the discs, line up four, and outsmart the arcade AI.</p>
+          </header>
+          <section class="game-area">
+            <section class="status-panel">
+              <p id="status" class="status-text">Your turn! Tap or click a column to drop a disc.</p>
+            </section>
+            <section class="board-wrapper">
+              <div id="board" class="board" aria-label="Connect Four board" role="grid"></div>
+            </section>
+            <section class="controls">
+              <button id="resetBtn" class="reset-btn" type="button" aria-label="Reset game">
+                Reset Game
+              </button>
+            </section>
+          </section>
+        </div>
       </main>
+
+      <footer class="arcade-footer">
+        © <span class="js-year"></span> Pixel Playground · Challenge a friend or warm up against the AI.
+      </footer>
     </div>
     <script src="script.js"></script>
+    <script src="../assets/js/arcade.js" defer></script>
   </body>
 </html>

--- a/connect-four/style.css
+++ b/connect-four/style.css
@@ -21,6 +21,10 @@ body {
   color: #f4f7ff;
 }
 
+.arcade-main {
+  align-items: center;
+}
+
 .game-shell {
   width: min(90vw, 960px);
   display: flex;
@@ -41,7 +45,7 @@ body {
   text-align: center;
 }
 
-.game-header h1 {
+.game-header h2 {
   margin: 0 0 0.5rem;
   font-family: 'Press Start 2P', cursive;
   font-size: clamp(1.5rem, 3vw, 2.1rem);

--- a/endless-runner/index.html
+++ b/endless-runner/index.html
@@ -3,29 +3,51 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Endless Runner</title>
+    <title>Endless Runner · Pixel Playground</title>
+    <link rel="stylesheet" href="../arcade.css" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <main class="game-shell">
-      <header class="hud">
-        <h1 class="game-title">Neon Runner</h1>
-        <div class="scoreboard">
-          <span class="label">Score:</span>
-          <span id="score">0</span>
+    <div class="arcade-page">
+      <header class="arcade-header card-surface">
+        <div class="arcade-header__meta">
+          <span class="brand-title">Pixel Playground</span>
+          <h1>Neon Endless Runner</h1>
+          <p>Leap, duck, and dash through synthwave streets while pushing your high score higher.</p>
         </div>
+        <a class="arcade-back" href="../index.html">
+          <span aria-hidden="true">⟵</span>
+          Back to Arcade
+        </a>
       </header>
-      <section class="canvas-wrapper">
-        <canvas id="game" width="960" height="540" role="img" aria-label="Endless runner game"></canvas>
-        <div class="controls-hint" aria-hidden="true">
-          <p>Press <strong>Space</strong> / <strong>Up</strong> to Jump &middot; <strong>Down</strong> to Duck</p>
-          <p>Tap left/right side to Jump/Duck on touch</p>
-        </div>
-      </section>
-      <footer class="hud">
-        <button id="restart" type="button" class="hidden">Restart</button>
+
+      <main class="arcade-main">
+        <section class="game-shell" aria-labelledby="runner-title">
+          <header class="hud">
+            <h2 id="runner-title" class="game-title">Neon Runner</h2>
+            <div class="scoreboard" role="status" aria-live="polite">
+              <span class="label">Score:</span>
+              <span id="score">0</span>
+            </div>
+          </header>
+          <section class="canvas-wrapper">
+            <canvas id="game" width="960" height="540" role="img" aria-label="Endless runner game"></canvas>
+            <div class="controls-hint" aria-hidden="true">
+              <p>Press <strong>Space</strong> / <strong>Up</strong> to Jump · <strong>Down</strong> to Duck</p>
+              <p>Tap left/right side to Jump/Duck on touch</p>
+            </div>
+          </section>
+          <footer class="hud">
+            <button id="restart" type="button" class="hidden">Restart</button>
+          </footer>
+        </section>
+      </main>
+
+      <footer class="arcade-footer">
+        © <span class="js-year"></span> Pixel Playground · Sync your reflexes with the beat.
       </footer>
-    </main>
+    </div>
     <script src="script.js" type="module"></script>
+    <script src="../assets/js/arcade.js" defer></script>
   </body>
 </html>

--- a/endless-runner/style.css
+++ b/endless-runner/style.css
@@ -23,7 +23,11 @@ body {
   background: radial-gradient(circle at top, rgba(57, 255, 20, 0.2), transparent 55%),
     radial-gradient(circle at bottom, rgba(255, 43, 214, 0.2), transparent 60%), var(--bg);
   color: var(--text);
-  padding: 1.5rem;
+  padding: clamp(1rem, 3vw, 2.5rem);
+}
+
+.arcade-main {
+  align-items: center;
 }
 
 .game-shell {

--- a/flappy-bird/index.html
+++ b/flappy-bird/index.html
@@ -3,48 +3,70 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Flappy Bird - Arcade Remix</title>
+    <title>Flappy Bird · Pixel Playground</title>
+    <link rel="stylesheet" href="../arcade.css" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div class="layout">
-      <section class="info-panel">
-        <h1>Flappy Bird - Neon Skies</h1>
-        <p>
-          Glide through a corridor of neon pipes and keep the bird afloat. Tap or
-          press space to flap, dodge obstacles, and chase your high score in this
-          retro-inspired remake.
-        </p>
-        <ul>
-          <li><strong>Flap:</strong> Spacebar, click, or tap</li>
-          <li><strong>Stay alive:</strong> Avoid pipes and the ground</li>
-          <li><strong>Restart:</strong> Hit the play again button or press R</li>
-        </ul>
-        <p class="tip">Pro tip: rhythmic taps keep you steady through tight gaps!</p>
-      </section>
-      <section class="game-panel">
-        <div class="game-container">
-          <div class="hud">
-            <div class="score" id="scoreDisplay">0</div>
-          </div>
-          <canvas
-            id="gameCanvas"
-            width="480"
-            height="640"
-            role="img"
-            aria-label="Flappy Bird arcade canvas"
-          ></canvas>
-          <div class="game-over hidden" id="gameOver">
-            <h2 class="game-over__title">Game Over</h2>
-            <p class="game-over__score">
-              Final Score: <span id="finalScore">0</span>
-            </p>
-            <button class="retry-button" id="retryButton">Play Again</button>
-            <p class="game-over__hint">Press Space, Tap, or R to restart</p>
-          </div>
+    <div class="arcade-page">
+      <header class="arcade-header card-surface">
+        <div class="arcade-header__meta">
+          <span class="brand-title">Pixel Playground</span>
+          <h1>Flappy Bird Remix</h1>
+          <p>Thread the neon skyline by timing each flap. Stay steady and chase a new best score.</p>
         </div>
-      </section>
+        <a class="arcade-back" href="../index.html">
+          <span aria-hidden="true">⟵</span>
+          Back to Arcade
+        </a>
+      </header>
+
+      <main class="arcade-main">
+        <div class="layout">
+          <section class="info-panel">
+            <h2>Flappy Bird - Neon Skies</h2>
+            <p>
+              Glide through a corridor of neon pipes and keep the bird afloat. Tap or
+              press space to flap, dodge obstacles, and chase your high score in this
+              retro-inspired remake.
+            </p>
+            <ul>
+              <li><strong>Flap:</strong> Spacebar, click, or tap</li>
+              <li><strong>Stay alive:</strong> Avoid pipes and the ground</li>
+              <li><strong>Restart:</strong> Hit the play again button or press R</li>
+            </ul>
+            <p class="tip">Pro tip: rhythmic taps keep you steady through tight gaps!</p>
+          </section>
+          <section class="game-panel">
+            <div class="game-container">
+              <div class="hud">
+                <div class="score" id="scoreDisplay">0</div>
+              </div>
+              <canvas
+                id="gameCanvas"
+                width="480"
+                height="640"
+                role="img"
+                aria-label="Flappy Bird arcade canvas"
+              ></canvas>
+              <div class="game-over hidden" id="gameOver">
+                <h2 class="game-over__title">Game Over</h2>
+                <p class="game-over__score">
+                  Final Score: <span id="finalScore">0</span>
+                </p>
+                <button class="retry-button" id="retryButton">Play Again</button>
+                <p class="game-over__hint">Press Space, Tap, or R to restart</p>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+
+      <footer class="arcade-footer">
+        © <span class="js-year"></span> Pixel Playground · Keep calm and flap on.
+      </footer>
     </div>
     <script src="script.js" defer></script>
+    <script src="../assets/js/arcade.js" defer></script>
   </body>
 </html>

--- a/flappy-bird/style.css
+++ b/flappy-bird/style.css
@@ -21,6 +21,10 @@ body {
   padding: 2rem 1.5rem;
 }
 
+.arcade-main {
+  align-items: stretch;
+}
+
 .layout {
   display: grid;
   grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
@@ -35,7 +39,7 @@ body {
   gap: 1.25rem;
 }
 
-h1 {
+.info-panel h2 {
   margin: 0;
   font-size: clamp(2.25rem, 4vw, 3rem);
   line-height: 1.1;

--- a/index.html
+++ b/index.html
@@ -173,8 +173,8 @@
           <span class="brand-title">Pixel Playground</span>
           <h1>Pick a challenge and press start</h1>
           <p>
-            A curated collection of fast, joyful arcade experiments. Each title is crafted
-            with the same visual language so hopping between games feels effortless.
+            Six bite-sized games built with vanilla JavaScript. Swap between puzzle, reflex,
+            and action challenges without leaving the arcade cabinet theme.
           </p>
         </div>
         <div class="badge-row">
@@ -229,20 +229,36 @@
               <p>Leap over hazards and keep momentum in this synthwave-inspired sprint.</p>
             </div>
           </a>
+
+          <a class="game-card card-surface" href="./simple_mover/" role="listitem">
+            <div class="card-thumb" aria-hidden="true">
+              <img src="./assets/thumbnails/simple-mover.svg" alt="" loading="lazy" />
+            </div>
+            <div class="card-meta">
+              <span>Arcade Trainer</span>
+              <h2>Simple Mover</h2>
+              <p>Dash around the neon arena, collect stars, and avoid the reactive walls.</p>
+            </div>
+          </a>
+
+          <a class="game-card card-surface" href="./tetris_knockoff/" role="listitem">
+            <div class="card-thumb" aria-hidden="true">
+              <img src="./assets/thumbnails/block-drop.svg" alt="" loading="lazy" />
+            </div>
+            <div class="card-meta">
+              <span>Falling Blocks</span>
+              <h2>Block Drop</h2>
+              <p>Stack tetrominoes with precision timing to clear lines and climb the ranks.</p>
+            </div>
+          </a>
         </div>
       </main>
 
       <footer>
-        © <span id="year"></span> Pixel Playground Arcade · Built for browsers big and small.
+        © <span class="js-year"></span> Pixel Playground Arcade · Crafted with vanilla HTML, CSS, and
+        JavaScript.
       </footer>
     </div>
-
-    <script>
-      const yearEl = document.getElementById('year');
-      const currentYear = new Date().getFullYear();
-      if (yearEl) {
-        yearEl.textContent = currentYear;
-      }
-    </script>
+    <script src="./assets/js/arcade.js" defer></script>
   </body>
 </html>

--- a/simple_mover/index.html
+++ b/simple_mover/index.html
@@ -8,41 +8,64 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <main class="layout">
-    <section class="game-panel">
-      <div class="game-container">
-        <canvas
-          id="game"
-          width="960"
-          height="600"
-          aria-label="Simple mover game"
-          role="img"
-        ></canvas>
-        <div
-          id="game-over"
-          class="game-over"
-          role="alertdialog"
-          aria-modal="true"
-          aria-labelledby="game-over-title"
-          hidden
-        >
-          <h2 id="game-over-title">Game Over</h2>
-          <p>You bumped into a wall, but you can try again!</p>
-          <p class="game-over__score">Your score: <span id="final-score">0</span></p>
-          <button id="retry-btn" type="button" class="retry-button">Play again</button>
-        </div>
+  <div class="arcade-page">
+    <header class="arcade-header card-surface">
+      <div class="arcade-header__meta">
+        <span class="brand-title">Pixel Playground</span>
+        <h1>Simple Mover</h1>
+        <p>Collect stars, dash through tight spots, and avoid the reactive walls.</p>
       </div>
-    </section>
-    <section class="info-panel">
-      <h1>Simple Mover</h1>
-      <p>Use the arrow keys or WASD to move the blue square. Collect stars to gain points and avoid the red walls!</p>
-      <ul>
-        <li><strong>Arrow Keys / WASD</strong>: Move</li>
-        <li><strong>Space</strong>: Dash (short burst of speed)</li>
-      </ul>
-      <p>The game ends if you hit a wall, but you can instantly restart from the retry popup.</p>
-    </section>
-  </main>
+      <a class="arcade-back" href="../index.html">
+        <span aria-hidden="true">⟵</span>
+        Back to Arcade
+      </a>
+    </header>
+
+    <main class="arcade-main">
+      <div class="layout">
+        <section class="game-panel">
+          <div class="game-container">
+            <canvas
+              id="game"
+              width="960"
+              height="600"
+              aria-label="Simple mover game"
+              role="img"
+            ></canvas>
+            <div
+              id="game-over"
+              class="game-over"
+              role="alertdialog"
+              aria-modal="true"
+              aria-labelledby="game-over-title"
+              hidden
+            >
+              <h2 id="game-over-title">Game Over</h2>
+              <p>You bumped into a wall, but you can try again!</p>
+              <p class="game-over__score">Your score: <span id="final-score">0</span></p>
+              <button id="retry-btn" type="button" class="retry-button">Play again</button>
+            </div>
+          </div>
+        </section>
+        <section class="info-panel">
+          <h2>Quick controls</h2>
+          <p>
+            Use the arrow keys or WASD to move the blue square. Collect stars to gain points and avoid the red walls!
+          </p>
+          <ul>
+            <li><strong>Arrow Keys / WASD</strong>: Move</li>
+            <li><strong>Space</strong>: Dash (short burst of speed)</li>
+          </ul>
+          <p>The game ends if you hit a wall, but you can instantly restart from the retry popup.</p>
+        </section>
+      </div>
+    </main>
+
+    <footer class="arcade-footer">
+      © <span class="js-year"></span> Pixel Playground · Practice precise movement and control.
+    </footer>
+  </div>
   <script src="script.js"></script>
+  <script src="../assets/js/arcade.js" defer></script>
 </body>
 </html>

--- a/simple_mover/styles.css
+++ b/simple_mover/styles.css
@@ -12,6 +12,11 @@ body {
   align-items: center;
   justify-content: center;
   background: var(--brand-bg, #080820);
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.arcade-main {
+  align-items: stretch;
 }
 
 .layout {
@@ -95,7 +100,7 @@ canvas {
   gap: 1rem;
 }
 
-h1 {
+.info-panel h2 {
   margin: 0;
   font-size: 2.5rem;
   line-height: 1.2;

--- a/tetris_knockoff/index.html
+++ b/tetris_knockoff/index.html
@@ -8,46 +8,64 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <main class="wrapper">
-      <section class="game-panel">
-        <header>
+    <div class="arcade-page">
+      <header class="arcade-header card-surface">
+        <div class="arcade-header__meta">
+          <span class="brand-title">Pixel Playground</span>
           <h1>Block Drop</h1>
-          <p>Use the arrow keys or WASD to move, rotate, and drop pieces.</p>
-        </header>
-        <canvas id="board" width="300" height="600" aria-label="Tetris playfield" role="img"></canvas>
-        <div class="hud">
-          <div class="stat">
-            <span class="label">Score</span>
-            <span id="score" class="value">0</span>
-          </div>
-          <div class="stat">
-            <span class="label">Lines</span>
-            <span id="lines" class="value">0</span>
-          </div>
-          <div class="stat">
-            <span class="label">Level</span>
-            <span id="level" class="value">1</span>
-          </div>
+          <p>Slide, rotate, and drop tetrominoes to clear lines and level up.</p>
         </div>
-        <button id="restart" type="button" class="button">Restart</button>
-      </section>
-      <aside class="next-panel">
-        <h2>Next</h2>
-        <canvas id="next" width="120" height="120" aria-label="Next tetromino preview"></canvas>
-        <section class="instructions">
-          <h3>Controls</h3>
-          <ul>
-            <li><strong>Move</strong>: Left / Right arrows or A / D</li>
-            <li><strong>Rotate</strong>: Up arrow or W</li>
-            <li><strong>Soft Drop</strong>: Down arrow or S</li>
-            <li><strong>Hard Drop</strong>: Space</li>
-          </ul>
+        <a class="arcade-back" href="../index.html">
+          <span aria-hidden="true">⟵</span>
+          Back to Arcade
+        </a>
+      </header>
+
+      <main class="arcade-main">
+        <section class="wrapper" aria-labelledby="block-drop-title">
+          <section class="game-panel">
+            <header>
+              <h2 id="block-drop-title">Block Drop</h2>
+              <p>Use the arrow keys or WASD to move, rotate, and drop pieces.</p>
+            </header>
+            <canvas id="board" width="300" height="600" aria-label="Tetris playfield" role="img"></canvas>
+            <div class="hud" role="status" aria-live="polite">
+              <div class="stat">
+                <span class="label">Score</span>
+                <span id="score" class="value">0</span>
+              </div>
+              <div class="stat">
+                <span class="label">Lines</span>
+                <span id="lines" class="value">0</span>
+              </div>
+              <div class="stat">
+                <span class="label">Level</span>
+                <span id="level" class="value">1</span>
+              </div>
+            </div>
+            <button id="restart" type="button" class="button">Restart</button>
+          </section>
+          <aside class="next-panel">
+            <h2>Next</h2>
+            <canvas id="next" width="120" height="120" aria-label="Next tetromino preview"></canvas>
+            <section class="instructions">
+              <h3>Controls</h3>
+              <ul>
+                <li><strong>Move</strong>: Left / Right arrows or A / D</li>
+                <li><strong>Rotate</strong>: Up arrow or W</li>
+                <li><strong>Soft Drop</strong>: Down arrow or S</li>
+                <li><strong>Hard Drop</strong>: Space</li>
+              </ul>
+            </section>
+          </aside>
         </section>
-      </aside>
-    </main>
-    <footer>
-      <p>Built with vanilla JavaScript &amp; canvas.</p>
-    </footer>
+      </main>
+
+      <footer class="arcade-footer">
+        © <span class="js-year"></span> Pixel Playground · Master the stack to climb the leaderboard.
+      </footer>
+    </div>
     <script src="script.js" defer></script>
+    <script src="../assets/js/arcade.js" defer></script>
   </body>
 </html>

--- a/tetris_knockoff/styles.css
+++ b/tetris_knockoff/styles.css
@@ -18,13 +18,16 @@ body {
   background: var(--brand-bg, radial-gradient(circle at top, #1e293b, #0f172a));
   color: var(--text);
   display: flex;
-  flex-direction: column;
+  justify-content: center;
   align-items: center;
-  justify-content: space-between;
-  padding: 2rem 1rem;
+  padding: clamp(1.5rem, 4vw, 3rem);
 }
 
-main.wrapper {
+.arcade-main {
+  align-items: stretch;
+}
+
+.wrapper {
   display: grid;
   gap: 2rem;
   grid-template-columns: minmax(280px, 1fr) minmax(180px, 240px);
@@ -124,17 +127,12 @@ canvas {
   font-size: 0.9rem;
 }
 
-footer {
-  color: rgba(226, 232, 240, 0.6);
-  font-size: 0.8rem;
-}
-
 @media (max-width: 768px) {
   body {
     padding: 1.5rem 1rem;
   }
 
-  main.wrapper {
+  .wrapper {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- refresh the homepage to act as an arcade lobby with all six games, updated copy, and new thumbnails
- wrap every game in a shared arcade shell with consistent header, back button, footer, and supporting styles/scripts
- document the project layout and setup steps in a new README

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d924961e50832ca29c67b9ffcc9ac6