### PR TITLE
Fix 2048 overlay remaining visible

### DIFF
--- a/2048/style.css
+++ b/2048/style.css
@@ -280,6 +280,10 @@ body {
   backdrop-filter: blur(8px);
 }
 
+.message[hidden] {
+  display: none !important;
+}
+
 .message-box {
   display: grid;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- ensure the in-game message overlay respects the hidden attribute so the board is playable on load

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d933887268832c985f0d79d0b8f6e8