### PR TITLE
Improve simple mover arena and flow

### DIFF
--- a/simple_mover/index.html
+++ b/simple_mover/index.html
@@ -27,24 +27,11 @@
           <div class="game-container">
             <canvas
               id="game"
-              width="960"
-              height="600"
+              width="1200"
+              height="720"
               aria-label="Simple mover game"
               role="img"
             ></canvas>
-            <div
-              id="game-over"
-              class="game-over"
-              role="alertdialog"
-              aria-modal="true"
-              aria-labelledby="game-over-title"
-              hidden
-            >
-              <h2 id="game-over-title">Game Over</h2>
-              <p>You bumped into a wall, but you can try again!</p>
-              <p class="game-over__score">Your score: <span id="final-score">0</span></p>
-              <button id="retry-btn" type="button" class="retry-button">Play again</button>
-            </div>
           </div>
         </section>
         <section class="info-panel">
@@ -55,8 +42,12 @@
           <ul>
             <li><strong>Arrow Keys / WASD</strong>: Move</li>
             <li><strong>Space</strong>: Dash (short burst of speed)</li>
+            <li><strong>R</strong>: Restart instantly after a crash</li>
           </ul>
-          <p>The game ends if you hit a wall, but you can instantly restart from the retry popup.</p>
+          <p>
+            Colliding with a wall pauses the action briefly before you respawn in a now-larger arena—press
+            <strong>R</strong> if you want to restart immediately.
+          </p>
         </section>
       </div>
     </main>

--- a/simple_mover/styles.css
+++ b/simple_mover/styles.css
@@ -48,51 +48,6 @@ canvas {
   position: relative;
 }
 
-.game-over {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  text-align: center;
-  background: rgba(6, 9, 15, 0.88);
-  padding: 2.5rem 2rem;
-  border-radius: 0.85rem;
-  backdrop-filter: blur(4px);
-}
-
-.game-over__score {
-  margin: 0;
-  font-size: 1.1rem;
-  color: #bcd6ff;
-}
-
-.retry-button {
-  appearance: none;
-  border: none;
-  background: linear-gradient(135deg, #4db5ff, #2563eb);
-  color: #f8fbff;
-  font-weight: 600;
-  font-size: 1rem;
-  padding: 0.75rem 1.75rem;
-  border-radius: 999px;
-  cursor: pointer;
-  box-shadow: 0 1rem 2.5rem rgba(37, 99, 235, 0.45);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.retry-button:focus-visible {
-  outline: 3px solid rgba(77, 181, 255, 0.75);
-  outline-offset: 4px;
-}
-
-.retry-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 1.2rem 2.75rem rgba(37, 99, 235, 0.5);
-}
-
 .info-panel {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- expand the Simple Mover play space and update the control hints for the new restart shortcut
- rebuild the gameplay loop to remove the blocking game-over overlay, add auto-respawn messaging, and reshape the wall layout
- clean up unused overlay styles now that the pop-up has been removed

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d93366744c832c850abb9ead866932