### PR TITLE
Add neon brick breaker game

### DIFF
--- a/assets/thumbnails/brick-breaker.svg
+++ b/assets/thumbnails/brick-breaker.svg
@@ -1,0 +1,39 @@
+<svg width="400" height="300" viewBox="0 0 400 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bb-bg" x1="200" y1="0" x2="200" y2="300" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#070B2D" />
+      <stop offset="0.5" stop-color="#101B4C" />
+      <stop offset="1" stop-color="#08091E" />
+    </linearGradient>
+    <linearGradient id="bb-paddle" x1="140" y1="228" x2="260" y2="228" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7DFBFF" />
+      <stop offset="1" stop-color="#F98BFF" />
+    </linearGradient>
+    <linearGradient id="bb-brick" x1="0" y1="0" x2="0" y2="28" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF" stop-opacity="0.9" />
+      <stop offset="0.4" stop-color="#7DFBFF" />
+      <stop offset="1" stop-color="#19245D" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" rx="28" fill="url(#bb-bg)" />
+  <g opacity="0.3" stroke="#6E82F7" stroke-width="1">
+    <path d="M40 80H360" />
+    <path d="M40 120H360" />
+    <path d="M40 160H360" />
+    <path d="M40 200H360" />
+  </g>
+  <g transform="translate(80 60)" stroke="#D9E2FF" stroke-opacity="0.6" stroke-width="1.4">
+    <rect width="60" height="26" rx="10" fill="url(#bb-brick)" />
+    <rect x="70" width="60" height="26" rx="10" fill="url(#bb-brick)" />
+    <rect x="140" width="60" height="26" rx="10" fill="url(#bb-brick)" />
+    <rect x="210" width="60" height="26" rx="10" fill="url(#bb-brick)" />
+    <rect x="0" y="36" width="60" height="26" rx="10" fill="url(#bb-brick)" />
+    <rect x="70" y="36" width="60" height="26" rx="10" fill="url(#bb-brick)" />
+    <rect x="140" y="36" width="60" height="26" rx="10" fill="url(#bb-brick)" />
+    <rect x="210" y="36" width="60" height="26" rx="10" fill="url(#bb-brick)" />
+  </g>
+  <rect x="140" y="228" width="120" height="18" rx="10" fill="url(#bb-paddle)" stroke="rgba(255,255,255,0.4)" stroke-width="2" />
+  <circle cx="210" cy="210" r="12" fill="#E9FCFF" stroke="#A6C8FF" stroke-width="2" />
+  <circle cx="210" cy="210" r="6" fill="#7AD8FF" />
+  <circle cx="210" cy="210" r="3" fill="#FFFFFF" />
+</svg>

--- a/brick-breaker-clone/index.html
+++ b/brick-breaker-clone/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Neon Brick Breaker</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="game-shell">
+      <header class="hud">
+        <h1>Neon Brick Breaker</h1>
+        <p class="tagline">Break every block, keep the ball alive, and climb the levels.</p>
+        <div class="scoreboard">
+          <div class="score-tile">
+            <span class="label">Score</span>
+            <span class="value" id="score">0</span>
+          </div>
+          <div class="score-tile">
+            <span class="label">Level</span>
+            <span class="value" id="level">1</span>
+          </div>
+          <div class="score-tile">
+            <span class="label">Lives</span>
+            <span class="value" id="lives">3</span>
+          </div>
+        </div>
+      </header>
+
+      <section class="canvas-stage">
+        <canvas id="gameCanvas" width="900" height="600" aria-label="Brick breaker play field"></canvas>
+        <div class="overlay" id="overlay" hidden>
+          <div class="overlay-card">
+            <h2 id="overlay-title">Ready?</h2>
+            <p id="overlay-message">
+              Use the arrow keys or move your mouse to slide the paddle. Smash every brick without losing all lives.
+            </p>
+            <button type="button" id="overlay-action">Start game</button>
+            <p class="overlay-tip">Press space to pause or resume mid game.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/brick-breaker-clone/script.js
+++ b/brick-breaker-clone/script.js
@@ -1,0 +1,456 @@
+const canvas = document.getElementById("gameCanvas");
+const ctx = canvas.getContext("2d");
+
+const overlay = document.getElementById("overlay");
+const overlayTitle = document.getElementById("overlay-title");
+const overlayMessage = document.getElementById("overlay-message");
+const overlayAction = document.getElementById("overlay-action");
+const scoreEl = document.getElementById("score");
+const levelEl = document.getElementById("level");
+const livesEl = document.getElementById("lives");
+
+const paddle = {
+  width: 140,
+  height: 18,
+  x: 0,
+  y: canvas.height - 70,
+  speed: 540,
+  moveDir: 0,
+};
+
+const ball = {
+  radius: 10,
+  x: canvas.width / 2,
+  y: canvas.height - 90,
+  vx: 0,
+  vy: 0,
+  speed: 360,
+  onPaddle: true,
+};
+
+let bricks = [];
+let score = 0;
+let level = 1;
+let lives = 3;
+let gameState = "intro"; // intro | running | paused | between | over
+let lastTime = performance.now();
+
+const COLORS = ["#77f0ff", "#69f7a3", "#f7d96b", "#ff8cf9", "#ff6584"];
+
+function updateHud() {
+  scoreEl.textContent = score.toString();
+  levelEl.textContent = level.toString();
+  livesEl.textContent = lives.toString();
+}
+
+function showOverlay(title, message, actionLabel) {
+  overlayTitle.textContent = title;
+  overlayMessage.textContent = message;
+  overlayAction.textContent = actionLabel;
+  overlay.hidden = false;
+}
+
+function hideOverlay() {
+  overlay.hidden = true;
+}
+
+function resetBall() {
+  ball.onPaddle = true;
+  ball.x = paddle.x + paddle.width / 2;
+  ball.y = paddle.y - ball.radius - 2;
+  ball.vx = 0;
+  ball.vy = 0;
+  ball.speed = 360 + (level - 1) * 28;
+}
+
+function launchBall() {
+  ball.onPaddle = false;
+  const angle = (-25 + Math.random() * 50) * (Math.PI / 180);
+  ball.vx = Math.sin(angle) * ball.speed;
+  ball.vy = -Math.cos(angle) * ball.speed;
+}
+
+function buildBricks() {
+  bricks = [];
+  const cols = 10;
+  const baseRows = 3 + Math.min(level - 1, 2);
+  const extraRows = Math.floor((level - 1) / 3);
+  const rows = Math.min(baseRows + extraRows, 8);
+  const brickWidth = 76;
+  const brickHeight = 26;
+  const gap = 8;
+  const totalWidth = cols * brickWidth + (cols - 1) * gap;
+  const offsetX = (canvas.width - totalWidth) / 2;
+  const offsetY = 90;
+
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const durability = 1 + Math.floor((row + level - 1) / 3);
+      bricks.push({
+        x: offsetX + col * (brickWidth + gap),
+        y: offsetY + row * (brickHeight + gap),
+        width: brickWidth,
+        height: brickHeight,
+        hits: durability,
+        maxHits: durability,
+        alive: true,
+      });
+    }
+  }
+}
+
+function startLevel(newLevel = false) {
+  if (newLevel) {
+    level += 1;
+    lives = Math.min(lives + 1, 6);
+  }
+  paddle.width = Math.max(90, 140 - (level - 1) * 6);
+  paddle.x = (canvas.width - paddle.width) / 2;
+  buildBricks();
+  resetBall();
+  updateHud();
+}
+
+function startRun(launch = true) {
+  gameState = "running";
+  lastTime = performance.now();
+  if (launch) {
+    launchBall();
+  }
+}
+
+function loseLife() {
+  lives -= 1;
+  updateHud();
+  if (lives <= 0) {
+    gameState = "over";
+    showOverlay(
+      "Game over",
+      `You cleared ${level} ${level === 1 ? "level" : "levels"} and scored ${score} points.`,
+      "Play again"
+    );
+  } else {
+    resetBall();
+    showOverlay("Ouch!", "You lost a life. Ready to jump back in?", "Resume");
+    gameState = "between";
+  }
+}
+
+function handleBrickHit(brick) {
+  brick.hits -= 1;
+  score += 100 * brick.maxHits;
+  updateHud();
+  if (brick.hits <= 0) {
+    brick.alive = false;
+  }
+
+  const remaining = bricks.filter((b) => b.alive).length;
+  if (remaining === 0) {
+    gameState = "between";
+    showOverlay("Level clear!", `Level ${level} complete. Ready for more heat?`, "Next level");
+  }
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function drawRoundedRectPath(x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + width - r, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  ctx.lineTo(x + r, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function update(delta) {
+  // Paddle movement
+  paddle.x += paddle.moveDir * paddle.speed * delta;
+  paddle.x = clamp(paddle.x, 0, canvas.width - paddle.width);
+
+  if (ball.onPaddle) {
+    ball.x = paddle.x + paddle.width / 2;
+    ball.y = paddle.y - ball.radius - 2;
+  } else {
+    ball.x += ball.vx * delta;
+    ball.y += ball.vy * delta;
+  }
+
+  // Wall collisions
+  if (ball.x - ball.radius <= 0 && ball.vx < 0) {
+    ball.x = ball.radius;
+    ball.vx *= -1;
+  }
+
+  if (ball.x + ball.radius >= canvas.width && ball.vx > 0) {
+    ball.x = canvas.width - ball.radius;
+    ball.vx *= -1;
+  }
+
+  if (ball.y - ball.radius <= 0 && ball.vy < 0) {
+    ball.y = ball.radius;
+    ball.vy *= -1;
+  }
+
+  if (ball.y - ball.radius > canvas.height) {
+    loseLife();
+  }
+
+  // Paddle collision
+  if (!ball.onPaddle) {
+    const withinX = ball.x + ball.radius >= paddle.x && ball.x - ball.radius <= paddle.x + paddle.width;
+    const withinY = ball.y + ball.radius >= paddle.y && ball.y - ball.radius <= paddle.y + paddle.height;
+    if (withinX && withinY && ball.vy > 0) {
+      ball.y = paddle.y - ball.radius;
+      const relative = (ball.x - (paddle.x + paddle.width / 2)) / (paddle.width / 2);
+      const maxBounce = (70 * Math.PI) / 180; // 70 degrees
+      const clamped = clamp(relative, -1, 1);
+      const angle = clamped * maxBounce;
+      const speed = Math.min(Math.hypot(ball.vx, ball.vy) * 1.03, 760);
+      ball.vx = Math.sin(angle) * speed;
+      ball.vy = -Math.cos(angle) * speed;
+    }
+  }
+
+  // Brick collisions
+  if (!ball.onPaddle) {
+    for (const brick of bricks) {
+      if (!brick.alive) continue;
+      if (
+        ball.x + ball.radius < brick.x ||
+        ball.x - ball.radius > brick.x + brick.width ||
+        ball.y + ball.radius < brick.y ||
+        ball.y - ball.radius > brick.y + brick.height
+      ) {
+        continue;
+      }
+
+      const overlapLeft = ball.x + ball.radius - brick.x;
+      const overlapRight = brick.x + brick.width - (ball.x - ball.radius);
+      const overlapTop = ball.y + ball.radius - brick.y;
+      const overlapBottom = brick.y + brick.height - (ball.y - ball.radius);
+      const minOverlap = Math.min(overlapLeft, overlapRight, overlapTop, overlapBottom);
+
+      if (minOverlap === overlapLeft || minOverlap === overlapRight) {
+        ball.vx *= -1;
+      } else {
+        ball.vy *= -1;
+      }
+
+      handleBrickHit(brick);
+      break;
+    }
+  }
+}
+
+function drawBackground() {
+  const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  gradient.addColorStop(0, "#06071b");
+  gradient.addColorStop(0.45, "#0e1234");
+  gradient.addColorStop(1, "#06071b");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.strokeStyle = "rgba(120, 150, 255, 0.12)";
+  ctx.lineWidth = 1;
+  for (let y = 80; y < canvas.height; y += 40) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(canvas.width, y);
+    ctx.stroke();
+  }
+  for (let x = 0; x < canvas.width; x += 60) {
+    ctx.beginPath();
+    ctx.moveTo(x, 80);
+    ctx.lineTo(x, canvas.height);
+    ctx.stroke();
+  }
+}
+
+function drawPaddle() {
+  ctx.fillStyle = "rgba(108, 247, 255, 0.9)";
+  const radius = 12;
+  const { x, y, width, height } = paddle;
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + width - radius, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+  ctx.lineTo(x + width, y + height - radius);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+  ctx.lineTo(x + radius, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+  ctx.lineTo(x, y + radius);
+  ctx.quadraticCurveTo(x, y, x + radius, y);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.4)";
+  ctx.lineWidth = 2;
+  ctx.stroke();
+}
+
+function drawBall() {
+  ctx.beginPath();
+  ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
+  const gradient = ctx.createRadialGradient(ball.x - 4, ball.y - 4, 2, ball.x, ball.y, ball.radius);
+  gradient.addColorStop(0, "#ffffff");
+  gradient.addColorStop(0.4, "#b6f9ff");
+  gradient.addColorStop(1, "#61a1ff");
+  ctx.fillStyle = gradient;
+  ctx.fill();
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.4)";
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+}
+
+function drawBricks() {
+  for (const brick of bricks) {
+    if (!brick.alive) continue;
+    const strength = brick.maxHits;
+    const colorIndex = Math.min(COLORS.length - 1, strength - 1);
+    const color = COLORS[colorIndex];
+
+    const gradient = ctx.createLinearGradient(brick.x, brick.y, brick.x, brick.y + brick.height);
+    gradient.addColorStop(0, "#ffffff");
+    gradient.addColorStop(0.25, color);
+    gradient.addColorStop(1, "#1a1e44");
+    ctx.fillStyle = gradient;
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.35)";
+    ctx.lineWidth = 1.3;
+
+    drawRoundedRectPath(brick.x, brick.y, brick.width, brick.height, 10);
+    ctx.fill();
+    ctx.stroke();
+  }
+}
+
+function draw() {
+  drawBackground();
+  drawPaddle();
+  drawBall();
+  drawBricks();
+}
+
+function gameLoop(timestamp) {
+  const delta = Math.min((timestamp - lastTime) / 1000, 0.04);
+  lastTime = timestamp;
+
+  if (gameState === "running") {
+    update(delta);
+  }
+
+  draw();
+  requestAnimationFrame(gameLoop);
+}
+
+requestAnimationFrame(gameLoop);
+
+overlayAction.addEventListener("click", () => {
+  if (gameState === "intro") {
+    score = 0;
+    level = 1;
+    lives = 3;
+    startLevel();
+    hideOverlay();
+    updateHud();
+    startRun(true);
+  } else if (gameState === "between") {
+    if (bricks.every((brick) => !brick.alive)) {
+      startLevel(true);
+      hideOverlay();
+      startRun(true);
+    } else {
+      hideOverlay();
+      startRun(false);
+    }
+  } else if (gameState === "over") {
+    score = 0;
+    level = 1;
+    lives = 3;
+    startLevel();
+    hideOverlay();
+    updateHud();
+    startRun(true);
+  } else if (gameState === "paused") {
+    hideOverlay();
+    startRun(false);
+  }
+});
+
+function togglePause() {
+  if (gameState === "running") {
+    gameState = "paused";
+    showOverlay("Paused", "Take a breather. Ready when you are!", "Resume");
+  } else if (gameState === "paused") {
+    gameState = "between";
+    hideOverlay();
+    startRun(false);
+  }
+}
+
+document.addEventListener("keydown", (event) => {
+  if (event.code === "ArrowLeft" || event.code === "KeyA") {
+    paddle.moveDir = -1;
+    event.preventDefault();
+  } else if (event.code === "ArrowRight" || event.code === "KeyD") {
+    paddle.moveDir = 1;
+    event.preventDefault();
+  } else if (event.code === "Space") {
+    event.preventDefault();
+    if (gameState === "intro" || gameState === "over") return;
+    if (gameState === "running" && !ball.onPaddle) {
+      togglePause();
+    } else if (gameState === "paused") {
+      togglePause();
+    } else if (ball.onPaddle && gameState === "running") {
+      launchBall();
+    }
+  }
+});
+
+document.addEventListener("keyup", (event) => {
+  if (
+    event.code === "ArrowLeft" ||
+    event.code === "ArrowRight" ||
+    event.code === "KeyA" ||
+    event.code === "KeyD"
+  ) {
+    if (
+      (event.code === "ArrowLeft" || event.code === "KeyA") &&
+      paddle.moveDir === -1
+    ) {
+      paddle.moveDir = 0;
+    } else if (
+      (event.code === "ArrowRight" || event.code === "KeyD") &&
+      paddle.moveDir === 1
+    ) {
+      paddle.moveDir = 0;
+    }
+  }
+});
+
+canvas.addEventListener("pointermove", (event) => {
+  const rect = canvas.getBoundingClientRect();
+  const position = event.clientX - rect.left;
+  paddle.x = clamp(position - paddle.width / 2, 0, canvas.width - paddle.width);
+});
+
+canvas.addEventListener("pointerdown", () => {
+  if (gameState === "running" && ball.onPaddle) {
+    launchBall();
+  }
+});
+
+showOverlay(
+  "Neon Brick Breaker",
+  "Smash through neon blocks with your paddle. Clear waves to climb levels and earn extra lives.",
+  "Start game"
+);
+updateHud();

--- a/brick-breaker-clone/style.css
+++ b/brick-breaker-clone/style.css
@@ -1,0 +1,167 @@
+:root {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at 15% 20%, rgba(86, 158, 255, 0.3) 0%, rgba(16, 14, 39, 0.92) 55%, rgba(8, 8, 18, 1) 100%);
+  --panel: rgba(24, 28, 62, 0.82);
+  --panel-border: rgba(120, 160, 255, 0.25);
+  --accent: #6cf7ff;
+  --accent-2: #ff8cf9;
+  --text-dim: rgba(230, 238, 255, 0.7);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: var(--bg);
+  color: #f7fbff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.game-shell {
+  width: min(1024px, 100%);
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.6rem);
+}
+
+.hud {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  box-shadow: 0 24px 64px rgba(6, 10, 35, 0.4);
+  display: grid;
+  gap: 1rem;
+}
+
+.hud h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: 0.04em;
+}
+
+.tagline {
+  margin: 0;
+  font-size: clamp(1rem, 2.4vw, 1.2rem);
+  color: var(--text-dim);
+}
+
+.scoreboard {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.score-tile {
+  flex: 1 1 140px;
+  background: rgba(16, 21, 50, 0.8);
+  border: 1px solid rgba(132, 196, 255, 0.2);
+  border-radius: 18px;
+  padding: 0.85rem 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.score-tile .label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  color: rgba(188, 209, 255, 0.6);
+}
+
+.score-tile .value {
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.canvas-stage {
+  position: relative;
+  border-radius: 24px;
+  overflow: hidden;
+  border: 1px solid rgba(132, 196, 255, 0.22);
+  background: linear-gradient(160deg, rgba(16, 26, 66, 0.85), rgba(13, 12, 30, 0.95));
+  box-shadow: 0 26px 70px rgba(10, 13, 42, 0.65);
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(6, 8, 22, 0.78);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.overlay-card {
+  background: rgba(26, 32, 75, 0.94);
+  border: 1px solid rgba(132, 196, 255, 0.25);
+  border-radius: 20px;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+  max-width: 400px;
+}
+
+.overlay-card h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.2rem);
+}
+
+.overlay-card p {
+  margin: 0;
+  color: rgba(210, 226, 255, 0.78);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.overlay-tip {
+  font-size: 0.85rem;
+  color: rgba(210, 226, 255, 0.6);
+}
+
+.overlay button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.8rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #0c102a;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.overlay button:hover,
+.overlay button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 34px rgba(136, 226, 255, 0.4);
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1rem;
+  }
+
+  .game-shell {
+    gap: 1.5rem;
+  }
+
+  canvas {
+    height: 70vh;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -230,6 +230,17 @@
             </div>
           </a>
 
+          <a class="game-card card-surface" href="./brick-breaker-clone/" role="listitem">
+            <div class="card-thumb" aria-hidden="true">
+              <img src="./assets/thumbnails/brick-breaker.svg" alt="" loading="lazy" />
+            </div>
+            <div class="card-meta">
+              <span>Arcade Classic</span>
+              <h2>Neon Brick Breaker</h2>
+              <p>Reflect the energy sphere, shatter neon bricks, and chain combos as levels intensify.</p>
+            </div>
+          </a>
+
           <a class="game-card card-surface" href="./simple_mover/" role="listitem">
             <div class="card-thumb" aria-hidden="true">
               <img src="./assets/thumbnails/simple-mover.svg" alt="" loading="lazy" />


### PR DESCRIPTION
## Summary
- create a neon-styled brick breaker clone with paddle controls, multi-hit bricks, level progression, and pause handling
- design dedicated HUD and overlay styling for the brick breaker experience
- add a thumbnail and landing page card that links to the new game folder

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d9387f14a4832c870719e0ea961b31