### PR TITLE
Enhance Petak Wordle UX

### DIFF
--- a/petak/index.html
+++ b/petak/index.html
@@ -9,21 +9,33 @@
 <body>
   <main class="game-container">
     <header class="game-header">
-      <h1>Petak</h1>
-      <div class="language-picker">
-        <label for="language-select">Jezik:</label>
-        <select id="language-select"></select>
+      <div class="title-group">
+        <h1>Petak</h1>
+        <p class="subtitle">Srpski Wordle, uz malo sjaja ✨</p>
+      </div>
+      <div class="controls">
+        <div class="language-picker">
+          <label for="language-select">Jezik:</label>
+          <select id="language-select"></select>
+        </div>
+        <button class="reset-button" id="reset-button" type="button">Nova reč</button>
       </div>
     </header>
 
-    <section class="board" id="board" aria-live="polite"></section>
+    <section class="status-bar" id="status-bar" role="status" aria-live="polite"></section>
+
+    <section class="board" id="board" aria-live="polite" aria-label="Tabla za pogađanje"></section>
 
     <section class="keyboard" id="keyboard" aria-label="Virtuelna tastatura"></section>
 
-    <p class="instructions">
-      Pogodi skrivenu reč od pet slova za šest pokušaja. Zelena slova su na pravom mestu,
-      žuta su u reči, ali na pogrešnom mestu, dok siva nisu deo reči. Odaberi drugo pismo i listu reči preko menija iznad.
-    </p>
+    <details class="instructions">
+      <summary>Kako se igra?</summary>
+      <p>
+        Pogodi skrivenu reč od pet slova za šest pokušaja. Zelena slova su na pravom mestu,
+        žuta su u reči, ali na pogrešnom mestu, dok siva nisu deo reči. Odaberi drugo pismo
+        i listu reči preko menija iznad. Klikni na „Nova reč" za novi izazov.
+      </p>
+    </details>
   </main>
 
   <template id="board-row-template">

--- a/petak/style.css
+++ b/petak/style.css
@@ -1,29 +1,65 @@
 :root {
   color-scheme: light dark;
-  --bg: #f5f5f5;
-  --bg-dark: #121213;
+  --bg: #f7f7fb;
+  --bg-dark: #0f1016;
+  --panel: rgba(255, 255, 255, 0.78);
+  --panel-dark: rgba(22, 22, 28, 0.78);
   --tile-border: #d3d6da;
   --tile-border-dark: #3a3a3c;
   --text: #1a1a1a;
-  --text-dark: #f5f5f5;
+  --text-dark: #f8f8ff;
   --correct: #6aaa64;
   --present: #c9b458;
   --absent: #787c7e;
-  --keyboard-bg: #d3d6da;
+  --keyboard-bg: rgba(0, 0, 0, 0.04);
+  --keyboard-bg-dark: rgba(255, 255, 255, 0.06);
   --keyboard-text: #1a1a1a;
+  --keyboard-text-dark: #f8f8ff;
+  --accent: #6756f6;
+  --accent-dark: #7c6cff;
+  --status-info: #3a64d8;
+  --status-success: #2f9d63;
+  --status-error: #d64545;
+  --shadow: 0 10px 40px rgba(31, 38, 135, 0.12);
+  --shadow-dark: 0 12px 36px rgba(0, 0, 0, 0.45);
 }
 
 @media (prefers-color-scheme: dark) {
   body {
-    background-color: var(--bg-dark);
+    background: radial-gradient(circle at 20% 20%, #1f2231 0%, #0f1016 60%);
     color: var(--text-dark);
+  }
+  .game-container {
+    background: var(--panel-dark);
+    box-shadow: var(--shadow-dark);
+  }
+  .subtitle {
+    color: rgba(248, 248, 255, 0.7);
   }
   .tile {
     border-color: var(--tile-border-dark);
   }
   .keyboard-key {
-    background-color: #3a3a3c;
+    background-color: var(--keyboard-bg-dark);
+    color: var(--keyboard-text-dark);
+  }
+  .keyboard-key:hover,
+  .keyboard-key:focus-visible {
+    background-color: rgba(255, 255, 255, 0.12);
+  }
+  .reset-button {
+    background: rgba(255, 255, 255, 0.08);
     color: var(--text-dark);
+  }
+  .keyboard {
+    background-color: rgba(255, 255, 255, 0.08);
+  }
+  .instructions {
+    background-color: rgba(255, 255, 255, 0.08);
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+  }
+  .status-bar {
+    background-color: rgba(90, 116, 255, 0.14);
   }
 }
 
@@ -37,17 +73,23 @@ body {
   min-height: 100vh;
   display: flex;
   justify-content: center;
-  align-items: flex-start;
-  background-color: var(--bg);
+  align-items: center;
+  padding: clamp(1rem, 3vw, 3rem);
+  background: radial-gradient(circle at 20% 20%, #fefefe 0%, #f0f1f6 50%, #e7ebff 100%);
   color: var(--text);
 }
 
 .game-container {
-  width: min(600px, 100%);
-  padding: 1.5rem;
+  width: min(620px, 100%);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  background: var(--panel);
+  backdrop-filter: blur(16px);
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(255, 255, 255, 0.4);
 }
 
 .game-header {
@@ -57,11 +99,29 @@ body {
   gap: 1rem;
 }
 
+.title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
 .game-header h1 {
   margin: 0;
   font-size: clamp(2rem, 5vw, 3rem);
   letter-spacing: 0.2rem;
   text-transform: uppercase;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: clamp(0.85rem, 2.5vw, 1.05rem);
+  color: rgba(26, 26, 26, 0.65);
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .language-picker {
@@ -71,16 +131,72 @@ body {
 }
 
 .language-picker select {
-  padding: 0.4rem 0.6rem;
-  border-radius: 0.4rem;
-  border: 1px solid var(--tile-border);
-  background-color: white;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background-color: rgba(255, 255, 255, 0.9);
   font-size: 1rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.language-picker select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(103, 86, 246, 0.25);
+}
+
+.reset-button {
+  padding: 0.55rem 0.95rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, var(--accent), #8f8afc);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 6px 14px rgba(103, 86, 246, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.reset-button:hover,
+.reset-button:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(103, 86, 246, 0.45);
+}
+
+.status-bar {
+  min-height: 2.5rem;
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 0.8rem;
+  background-color: rgba(58, 100, 216, 0.12);
+  color: var(--status-info);
+  font-weight: 600;
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.status-bar.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.status-bar.success {
+  background-color: rgba(47, 157, 99, 0.12);
+  color: var(--status-success);
+}
+
+.status-bar.error {
+  background-color: rgba(214, 69, 69, 0.12);
+  color: var(--status-error);
 }
 
 .board {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .board-row {
@@ -93,17 +209,28 @@ body {
   position: relative;
   width: 100%;
   padding-top: 100%;
-  border: 2px solid var(--tile-border);
+  border: 2px solid rgba(0, 0, 0, 0.12);
   display: grid;
   place-items: center;
   font-size: clamp(1.5rem, 6vw, 2.2rem);
   font-weight: 700;
   text-transform: uppercase;
   border-radius: 0.4rem;
+  background-color: rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.08);
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
 }
 
 .tile.filled {
   border-color: var(--tile-border-dark);
+}
+
+.tile.flip {
+  animation: flip 0.6s ease;
+}
+
+.board-row.active .tile.filled {
+  animation: pop 0.15s ease;
 }
 
 .tile.correct {
@@ -127,6 +254,10 @@ body {
 .keyboard {
   display: grid;
   gap: 0.5rem;
+  padding: 0.6rem;
+  border-radius: 1rem;
+  background-color: rgba(255, 255, 255, 0.55);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
 .keyboard-row {
@@ -146,11 +277,17 @@ body {
   cursor: pointer;
   text-transform: uppercase;
   min-width: 2.6rem;
-  transition: transform 0.1s ease;
+  transition: transform 0.1s ease, background-color 0.2s ease;
 }
 
 .keyboard-key:active {
   transform: scale(0.95);
+}
+
+.keyboard-key:hover,
+.keyboard-key:focus-visible {
+  outline: none;
+  background-color: rgba(0, 0, 0, 0.08);
 }
 
 .keyboard-key.wide {
@@ -161,15 +298,95 @@ body {
   margin: 0;
   font-size: 0.95rem;
   line-height: 1.5;
+  background-color: rgba(255, 255, 255, 0.55);
+  padding: 1rem 1.2rem;
+  border-radius: 1rem;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+.instructions summary {
+  font-weight: 700;
+  cursor: pointer;
+  list-style: none;
+}
+
+.instructions summary::-webkit-details-marker {
+  display: none;
+}
+
+.instructions summary::after {
+  content: "+";
+  float: right;
+  transition: transform 0.3s ease;
+}
+
+.instructions[open] summary::after {
+  transform: rotate(45deg);
+}
+
+.shake {
+  animation: shake 0.35s ease;
+}
+
+@keyframes shake {
+  10%,
+  90% {
+    transform: translateX(-1px);
+  }
+
+  20%,
+  80% {
+    transform: translateX(2px);
+  }
+
+  30%,
+  50%,
+  70% {
+    transform: translateX(-4px);
+  }
+
+  40%,
+  60% {
+    transform: translateX(4px);
+  }
+}
+
+@keyframes pop {
+  0% {
+    transform: scale(0.9);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes flip {
+  0% {
+    transform: rotateX(0deg);
+  }
+
+  50% {
+    transform: rotateX(-90deg);
+  }
+
+  100% {
+    transform: rotateX(0deg);
+  }
 }
 
 @media (max-width: 600px) {
   .game-container {
-    padding: 1rem;
+    padding: 1.25rem;
   }
 
   .keyboard-key {
-    min-width: 2.2rem;
+    min-width: 2.4rem;
     padding: 0.6rem 0.4rem;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: flex-end;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the Petak Wordle layout with a modern glassmorphism-inspired shell, controls, and collapsible instructions
- replace alert popups with a reusable status bar, add tile animations, and shake feedback for invalid guesses
- add a quick reset button, disable input during reveals, and refresh keyboard styling for better usability

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d939399174832cbea277205bc3bba8