### PR TITLE
Revamp arcade hub with shuffle widget and new game

### DIFF
--- a/assets/js/arcade.js
+++ b/assets/js/arcade.js
@@ -3,4 +3,63 @@
   document.querySelectorAll('.js-year').forEach((el) => {
     el.textContent = year;
   });
+
+  const cards = Array.from(document.querySelectorAll('.game-grid .game-card'));
+  const totalGamesEl = document.querySelector('[data-total-games]');
+  const newGamesEl = document.querySelector('[data-new-games]');
+  const statusEl = document.querySelector('[data-status-rotator]');
+  const shuffleButton = document.querySelector('[data-action="shuffle"]');
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (totalGamesEl) {
+    totalGamesEl.textContent = cards.length.toString();
+  }
+
+  if (newGamesEl) {
+    const newGames = cards.filter((card) => card.dataset.status === 'new').length;
+    newGamesEl.textContent = newGames.toString();
+  }
+
+  const statusMessages = [
+    'Queueing power-ups... almost there!',
+    'Cycling neon lights for optimal vibes.',
+    'Listening for high-score whispers in the cabinet.',
+    'Spinning the arcade wheel for your next run.',
+  ];
+
+  if (statusEl) {
+    let statusIndex = 0;
+    setInterval(() => {
+      statusIndex = (statusIndex + 1) % statusMessages.length;
+      statusEl.textContent = statusMessages[statusIndex];
+    }, 7000);
+  }
+
+  if (shuffleButton && cards.length) {
+    let highlightTimeout;
+
+    shuffleButton.addEventListener('click', () => {
+      const choice = cards[Math.floor(Math.random() * cards.length)];
+
+      cards.forEach((card) => card.classList.remove('is-highlighted'));
+      choice.classList.add('is-highlighted');
+
+      const gameName = choice.querySelector('h2')?.textContent?.trim() ?? 'your next game';
+
+      if (statusEl) {
+        statusEl.textContent = `Arcade selected: ${gameName}!`;
+      }
+
+      if (highlightTimeout) {
+        clearTimeout(highlightTimeout);
+      }
+
+      highlightTimeout = window.setTimeout(() => {
+        choice.classList.remove('is-highlighted');
+      }, 4000);
+
+      choice.focus?.({ preventScroll: true });
+      choice.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
+    });
+  }
 })();

--- a/assets/thumbnails/neon-memory.svg
+++ b/assets/thumbnails/neon-memory.svg
@@ -1,0 +1,44 @@
+<svg width="320" height="200" viewBox="0 0 320 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="200" rx="24" fill="url(#paint0_linear)" />
+  <g filter="url(#filter0_d)">
+    <rect x="68" y="44" width="184" height="132" rx="20" fill="url(#paint1_linear)" stroke="rgba(255,255,255,0.15)" stroke-width="2" />
+    <g transform="translate(0,-6)">
+      <rect x="92" y="78" width="64" height="84" rx="14" fill="url(#paintCard1)" stroke="rgba(123,91,255,0.45)" stroke-width="2" />
+      <rect x="140" y="60" width="64" height="84" rx="14" fill="url(#paintCard2)" stroke="rgba(86,220,255,0.5)" stroke-width="2" />
+      <rect x="188" y="90" width="64" height="84" rx="14" fill="url(#paintCard3)" stroke="rgba(255,214,102,0.6)" stroke-width="2" />
+      <text x="172" y="112" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="34" fill="#F1F4FF">👾</text>
+      <text x="220" y="142" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="34" fill="#F1F4FF">💾</text>
+      <text x="124" y="150" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="34" fill="#F1F4FF">🔮</text>
+    </g>
+    <path d="M100 66h120" stroke="rgba(86,220,255,0.35)" stroke-width="4" stroke-linecap="round" stroke-dasharray="12 10" />
+    <path d="M116 170c40-22 88-22 128 0" stroke="rgba(123,209,255,0.35)" stroke-width="5" stroke-linecap="round" />
+  </g>
+  <defs>
+    <linearGradient id="paint0_linear" x1="40" y1="12" x2="280" y2="188" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0B0B2D" />
+      <stop offset="1" stop-color="#1A1F52" />
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="68" y1="44" x2="252" y2="176" gradientUnits="userSpaceOnUse">
+      <stop stop-color="rgba(18,24,60,0.92)" />
+      <stop offset="1" stop-color="rgba(10,16,44,0.95)" />
+    </linearGradient>
+    <linearGradient id="paintCard1" x1="92" y1="78" x2="156" y2="162" gradientUnits="userSpaceOnUse">
+      <stop stop-color="rgba(60,28,112,0.85)" />
+      <stop offset="1" stop-color="rgba(30,16,78,0.9)" />
+    </linearGradient>
+    <linearGradient id="paintCard2" x1="140" y1="60" x2="204" y2="144" gradientUnits="userSpaceOnUse">
+      <stop stop-color="rgba(24,82,134,0.85)" />
+      <stop offset="1" stop-color="rgba(14,32,94,0.9)" />
+    </linearGradient>
+    <linearGradient id="paintCard3" x1="188" y1="90" x2="252" y2="174" gradientUnits="userSpaceOnUse">
+      <stop stop-color="rgba(116,76,34,0.85)" />
+      <stop offset="1" stop-color="rgba(74,42,10,0.88)" />
+    </linearGradient>
+    <filter id="filter0_d" x="48" y="28" width="224" height="172" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="10" />
+      <feGaussianBlur stdDeviation="16" result="blur" />
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.02  0 0 0 0 0.08  0 0 0 0 0.24  0 0 0 0.42 0" result="shadow" />
+      <feBlend in="SourceGraphic" in2="shadow" mode="normal" />
+    </filter>
+  </defs>
+</svg>

--- a/assets/thumbnails/online-hustle.svg
+++ b/assets/thumbnails/online-hustle.svg
@@ -1,0 +1,47 @@
+<svg width="320" height="200" viewBox="0 0 320 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="200" rx="24" fill="url(#paint0_linear)"/>
+  <g filter="url(#filter0_d)">
+    <rect x="60" y="48" width="200" height="120" rx="16" fill="url(#paint1_linear)" stroke="rgba(255,255,255,0.18)" stroke-width="2" />
+    <path d="M76 152h168" stroke="rgba(123,209,255,0.6)" stroke-width="3" stroke-linecap="round" stroke-dasharray="6 8" />
+    <rect x="90" y="74" width="80" height="48" rx="10" fill="rgba(10,16,48,0.85)" stroke="rgba(123,91,255,0.55)" stroke-width="2" />
+    <path d="M102 102c8-14 30-14 38 0" stroke="rgba(123,209,255,0.85)" stroke-width="3" stroke-linecap="round" />
+    <circle cx="112" cy="94" r="6" fill="rgba(123,209,255,0.85)" />
+    <circle cx="132" cy="94" r="6" fill="rgba(123,91,255,0.85)" />
+    <rect x="186" y="74" width="64" height="54" rx="12" fill="rgba(123,91,255,0.18)" stroke="rgba(123,91,255,0.45)" stroke-width="2" />
+    <path d="M202 124h32" stroke="rgba(255,255,255,0.55)" stroke-width="3" stroke-linecap="round" />
+    <path d="M198 94h40" stroke="rgba(255,255,255,0.35)" stroke-width="4" stroke-linecap="round" stroke-dasharray="12 10" />
+    <g>
+      <circle cx="112" cy="154" r="16" fill="rgba(255,214,102,0.9)" stroke="rgba(255,240,180,0.8)" stroke-width="3" />
+      <text x="112" y="159" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="12" fill="#23133A">XP</text>
+    </g>
+    <g>
+      <circle cx="152" cy="154" r="12" fill="rgba(123,209,255,0.9)" stroke="rgba(180,236,255,0.8)" stroke-width="3" />
+      <text x="152" y="159" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="10" fill="#05102A">$</text>
+    </g>
+    <g>
+      <circle cx="188" cy="154" r="14" fill="rgba(164,120,255,0.9)" stroke="rgba(210,188,255,0.8)" stroke-width="3" />
+      <text x="188" y="159" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="10" fill="#0C0C24">+1</text>
+    </g>
+  </g>
+  <defs>
+    <linearGradient id="paint0_linear" x1="32" y1="12" x2="296" y2="188" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#120D3B" />
+      <stop offset="1" stop-color="#1B2B68" />
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="60" y1="48" x2="260" y2="168" gradientUnits="userSpaceOnUse">
+      <stop stop-color="rgba(28,36,92,0.95)" />
+      <stop offset="1" stop-color="rgba(14,18,52,0.95)" />
+    </linearGradient>
+    <filter id="filter0_d" x="40" y="32" width="240" height="160" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="10" />
+      <feGaussianBlur stdDeviation="18" result="blur" />
+      <feColorMatrix
+        in="blur"
+        type="matrix"
+        values="0 0 0 0 0.02  0 0 0 0 0.05  0 0 0 0 0.18  0 0 0 0.45 0"
+        result="shadow"
+      />
+      <feBlend in="SourceGraphic" in2="shadow" mode="normal" />
+    </filter>
+  </defs>
+</svg>

--- a/index.html
+++ b/index.html
@@ -22,13 +22,177 @@
       }
 
       .hero {
+        position: relative;
         display: grid;
-        gap: 1.5rem;
+        gap: clamp(1.75rem, 3vw, 2.4rem);
         padding: clamp(1.8rem, 4vw, 3rem);
-        background: linear-gradient(135deg, rgba(123, 91, 255, 0.28), rgba(12, 19, 67, 0.86));
+        background: linear-gradient(135deg, rgba(123, 91, 255, 0.3), rgba(12, 19, 67, 0.92));
         border-radius: 28px;
         border: 1px solid rgba(255, 255, 255, 0.08);
         box-shadow: 0 32px 60px rgba(5, 8, 31, 0.45);
+        overflow: hidden;
+      }
+
+      .hero::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(circle at 20% 20%, rgba(123, 209, 255, 0.14), transparent 45%),
+          radial-gradient(circle at 80% 30%, rgba(255, 135, 219, 0.18), transparent 50%),
+          radial-gradient(circle at 50% 80%, rgba(123, 91, 255, 0.18), transparent 50%);
+        filter: blur(0px);
+        opacity: 0.8;
+        pointer-events: none;
+      }
+
+      .hero-main,
+      .hero-widget {
+        position: relative;
+        z-index: 1;
+      }
+
+      .hero-main {
+        display: grid;
+        gap: clamp(1.5rem, 3vw, 2rem);
+      }
+
+      .hero-ticker {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 0.85rem 1.1rem;
+        border-radius: 16px;
+        background: rgba(10, 13, 42, 0.75);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        overflow: hidden;
+        position: relative;
+      }
+
+      .hero-ticker::before,
+      .hero-ticker::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        width: 48px;
+        height: 100%;
+        pointer-events: none;
+        z-index: 1;
+      }
+
+      .hero-ticker::before {
+        left: 0;
+        background: linear-gradient(90deg, rgba(10, 13, 42, 0.95), transparent);
+      }
+
+      .hero-ticker::after {
+        right: 0;
+        background: linear-gradient(270deg, rgba(10, 13, 42, 0.95), transparent);
+      }
+
+      .ticker-label {
+        font-size: 0.75rem;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: rgba(248, 249, 255, 0.6);
+        flex-shrink: 0;
+      }
+
+      .ticker-track {
+        display: flex;
+        gap: 2rem;
+        width: max-content;
+        animation: tickerMove 28s linear infinite;
+        will-change: transform;
+      }
+
+      .ticker-item {
+        white-space: nowrap;
+        font-size: 0.9rem;
+        color: rgba(248, 249, 255, 0.75);
+      }
+
+      .hero-widget {
+        display: grid;
+        gap: 1rem;
+        align-content: start;
+        padding: 1.5rem;
+      }
+
+      .hero-widget__badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.35rem;
+        padding: 0.35rem 0.9rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        background: rgba(123, 91, 255, 0.2);
+        border: 1px solid rgba(123, 91, 255, 0.4);
+      }
+
+      .hero-widget__text {
+        margin: 0;
+        font-size: 0.95rem;
+        color: rgba(248, 249, 255, 0.75);
+      }
+
+      .hero-widget__button {
+        border: none;
+        cursor: pointer;
+        padding: 0.75rem 1.35rem;
+        border-radius: 999px;
+        font-weight: 600;
+        font-size: 0.95rem;
+        letter-spacing: 0.02em;
+        background: linear-gradient(135deg, rgba(123, 91, 255, 0.95), rgba(86, 133, 255, 0.95));
+        color: #fff;
+        box-shadow: 0 18px 36px rgba(14, 18, 56, 0.55);
+        transition: transform 180ms ease, box-shadow 180ms ease, filter 180ms ease;
+      }
+
+      .hero-widget__button:hover,
+      .hero-widget__button:focus-visible {
+        transform: translateY(-2px);
+        box-shadow: 0 22px 44px rgba(14, 18, 56, 0.6);
+        filter: brightness(1.05);
+        outline: none;
+      }
+
+      .hero-widget__stats {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.75rem;
+        margin: 0;
+      }
+
+      .hero-widget__stats div {
+        display: grid;
+        gap: 0.35rem;
+        padding: 0.65rem 0.75rem;
+        border-radius: 12px;
+        background: rgba(12, 19, 67, 0.6);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+      }
+
+      .hero-widget__stats dt {
+        font-size: 0.75rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: rgba(248, 249, 255, 0.6);
+      }
+
+      .hero-widget__stats dd {
+        margin: 0;
+        font-size: 1.5rem;
+        font-weight: 600;
+      }
+
+      .hero-widget__status {
+        margin: 0;
+        font-size: 0.85rem;
+        color: rgba(248, 249, 255, 0.65);
       }
 
       .hero-heading {
@@ -88,6 +252,20 @@
         transition: transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease;
       }
 
+      .card-chip {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+        padding: 0.35rem 0.65rem;
+        border-radius: 999px;
+        font-size: 0.7rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        background: rgba(86, 220, 255, 0.2);
+        border: 1px solid rgba(86, 220, 255, 0.65);
+        color: rgba(200, 245, 255, 0.85);
+      }
+
       .game-card::after {
         content: '';
         position: absolute;
@@ -103,6 +281,17 @@
       .game-card:focus-visible {
         transform: translateY(-6px) scale(1.01);
         box-shadow: 0 26px 60px rgba(10, 14, 40, 0.55);
+      }
+
+      .game-card.is-highlighted {
+        transform: translateY(-8px) scale(1.015);
+        box-shadow: 0 32px 70px rgba(10, 18, 70, 0.65);
+      }
+
+      .game-card.is-highlighted::after {
+        opacity: 1;
+        border-color: rgba(86, 220, 255, 0.7);
+        box-shadow: 0 0 0 6px rgba(86, 220, 255, 0.15);
       }
 
       .game-card:hover::after,
@@ -162,6 +351,45 @@
 
         .hero {
           padding: 1.75rem;
+          grid-template-columns: minmax(0, 1fr);
+        }
+
+        .hero-widget__stats {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      @media (min-width: 960px) {
+        .hero {
+          grid-template-columns: minmax(0, 1fr) minmax(260px, 0.7fr);
+          align-items: stretch;
+        }
+
+        .hero-main {
+          align-self: center;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .ticker-track {
+          animation-duration: 0.01ms;
+          animation-iteration-count: 1;
+        }
+
+        .hero-widget__button,
+        .game-card,
+        .game-card::after {
+          transition: none;
+        }
+      }
+
+      @keyframes tickerMove {
+        from {
+          transform: translateX(0);
+        }
+
+        to {
+          transform: translateX(-50%);
         }
       }
     </style>
@@ -169,19 +397,52 @@
   <body>
     <div class="arcade-shell">
       <header class="hero">
-        <div class="hero-heading">
-          <span class="brand-title">Pixel Playground</span>
-          <h1>Pick a challenge and press start</h1>
-          <p>
-            Six bite-sized games built with vanilla JavaScript. Swap between puzzle, reflex,
-            and action challenges without leaving the arcade cabinet theme.
+        <div class="hero-main">
+          <div class="hero-heading">
+            <span class="brand-title">Pixel Playground</span>
+            <h1>Pick a challenge and press start</h1>
+            <p>
+              Eight bite-sized games built with vanilla JavaScript. Swap between puzzle, reflex,
+              and action challenges without leaving the arcade cabinet theme.
+            </p>
+          </div>
+          <div class="badge-row">
+            <span class="hero-badge">Keyboard + Touch Friendly</span>
+            <span class="hero-badge">No installs required</span>
+            <span class="hero-badge">Built with vanilla JS</span>
+          </div>
+          <div class="hero-ticker card-surface" role="status" aria-live="polite">
+            <span class="ticker-label">Now featuring</span>
+            <div class="ticker-track">
+              <span class="ticker-item">Neon Memory Challenge · Ultra-fast rounds for puzzle lovers</span>
+              <span class="ticker-item">Online Hustle Simulator · Build your pixel empire, no sleep required</span>
+              <span class="ticker-item">Brick Breaker Combo Mode · Chase perfect clears with new pacing tips</span>
+              <span class="ticker-item">Neon Memory Challenge · Ultra-fast rounds for puzzle lovers</span>
+              <span class="ticker-item">Online Hustle Simulator · Build your pixel empire, no sleep required</span>
+              <span class="ticker-item">Brick Breaker Combo Mode · Chase perfect clears with new pacing tips</span>
+            </div>
+          </div>
+        </div>
+        <aside class="hero-widget card-surface" aria-label="Arcade shuffle">
+          <span class="hero-widget__badge">Arcade Shuffle</span>
+          <p class="hero-widget__text">Not sure what to play? Let the arcade pick a surprise challenge.</p>
+          <button class="hero-widget__button" type="button" data-action="shuffle">
+            Surprise me
+          </button>
+          <dl class="hero-widget__stats">
+            <div>
+              <dt>Total games</dt>
+              <dd><span data-total-games>0</span></dd>
+            </div>
+            <div>
+              <dt>Fresh drops</dt>
+              <dd><span data-new-games>0</span></dd>
+            </div>
+          </dl>
+          <p class="hero-widget__status" data-status-rotator>
+            Press the surprise button to highlight your next adventure.
           </p>
-        </div>
-        <div class="badge-row">
-          <span class="hero-badge">Keyboard + Touch Friendly</span>
-          <span class="hero-badge">No installs required</span>
-          <span class="hero-badge">Built with vanilla JS</span>
-        </div>
+        </aside>
       </header>
 
       <main>
@@ -260,6 +521,30 @@
               <span>Falling Blocks</span>
               <h2>Block Drop</h2>
               <p>Stack tetrominoes with precision timing to clear lines and climb the ranks.</p>
+            </div>
+          </a>
+
+          <a class="game-card card-surface" href="./online-hustle-simulator/" role="listitem" data-status="new">
+            <span class="card-chip">New</span>
+            <div class="card-thumb" aria-hidden="true">
+              <img src="./assets/thumbnails/online-hustle.svg" alt="" loading="lazy" />
+            </div>
+            <div class="card-meta">
+              <span>Idle Tycoon</span>
+              <h2>Online Hustle Simulator</h2>
+              <p>Upgrade your pixel side gigs, keep the energy meter full, and grow your neon empire.</p>
+            </div>
+          </a>
+
+          <a class="game-card card-surface" href="./neon-memory/" role="listitem" data-status="new">
+            <span class="card-chip">New</span>
+            <div class="card-thumb" aria-hidden="true">
+              <img src="./assets/thumbnails/neon-memory.svg" alt="" loading="lazy" />
+            </div>
+            <div class="card-meta">
+              <span>Memory Rush</span>
+              <h2>Neon Memory</h2>
+              <p>Flip neon tiles, lock in the pairs, and clear the board before the tempo maxes out.</p>
             </div>
           </a>
         </div>

--- a/neon-memory/index.html
+++ b/neon-memory/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Neon Memory · Pixel Playground</title>
+    <link rel="stylesheet" href="../arcade.css" />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div class="arcade-page">
+      <header class="arcade-header card-surface">
+        <div class="arcade-header__meta">
+          <span class="brand-title">Pixel Playground</span>
+          <h1>Neon Memory</h1>
+          <p>Flip glowing tiles, remember the icons, and lock in every pair before the beat fades.</p>
+        </div>
+        <a class="arcade-back" href="../index.html">
+          <span aria-hidden="true">⟵</span>
+          Back to Arcade
+        </a>
+      </header>
+
+      <main class="arcade-main">
+        <section class="memory card-surface">
+          <header class="memory__top">
+            <div class="memory__intro">
+              <h2>Flip &amp; Match</h2>
+              <p>
+                Reveal two tiles at a time to find the matching neon glyphs. Earn a perfect score by
+                clearing the deck with the fewest turns.
+              </p>
+            </div>
+            <div class="memory__controls" role="status" aria-live="polite">
+              <div class="memory__stat">
+                <span class="label">Matches</span>
+                <span class="value" data-stat="matches">0</span>
+              </div>
+              <div class="memory__stat">
+                <span class="label">Turns</span>
+                <span class="value" data-stat="turns">0</span>
+              </div>
+              <div class="memory__stat">
+                <span class="label">Timer</span>
+                <span class="value" data-stat="time">0:00</span>
+              </div>
+              <button class="memory__reset" type="button" data-action="reset">Reset run</button>
+            </div>
+          </header>
+          <p class="memory__status" data-memory-status>Flip two cards to get started.</p>
+          <div class="memory__board" role="grid" aria-label="Neon memory board"></div>
+        </section>
+
+        <section class="memory-help card-surface">
+          <h2>How to play</h2>
+          <ol>
+            <li>Tap or click any tile to reveal the neon icon beneath.</li>
+            <li>Select a second tile &mdash; if the icons match, the pair locks in.</li>
+            <li>
+              Keep matching pairs to clear the deck. Finish with fewer turns to top the leaderboard
+              vibes.
+            </li>
+          </ol>
+          <p class="memory-help__tip">
+            Pro tip: track icons by their position rhythm &mdash; corners, edges, and center tiles each
+            have their own beat.
+          </p>
+        </section>
+      </main>
+
+      <footer class="arcade-footer">
+        © <span class="js-year"></span> Pixel Playground · Sharpen your recall and chase a perfect run.
+      </footer>
+    </div>
+    <script src="./script.js" defer></script>
+    <script src="../assets/js/arcade.js" defer></script>
+  </body>
+</html>

--- a/neon-memory/script.js
+++ b/neon-memory/script.js
@@ -1,0 +1,182 @@
+const SYMBOLS = ['💾', '👾', '🛸', '🎹', '🎯', '🔮'];
+const boardEl = document.querySelector('.memory__board');
+const matchesEl = document.querySelector('[data-stat="matches"]');
+const turnsEl = document.querySelector('[data-stat="turns"]');
+const timeEl = document.querySelector('[data-stat="time"]');
+const statusEl = document.querySelector('[data-memory-status]');
+const resetBtn = document.querySelector('[data-action="reset"]');
+
+let deck = [];
+let firstCard = null;
+let secondCard = null;
+let lockBoard = false;
+let matches = 0;
+let turns = 0;
+let timerId = null;
+let startTime = null;
+
+function shuffle(array) {
+  const copy = [...array];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+function formatTime(totalSeconds) {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function updateStats() {
+  if (matchesEl) {
+    matchesEl.textContent = matches.toString();
+  }
+  if (turnsEl) {
+    turnsEl.textContent = turns.toString();
+  }
+}
+
+function updateTimer() {
+  if (!timeEl) return;
+  if (!startTime) {
+    timeEl.textContent = '0:00';
+    return;
+  }
+  const elapsedSeconds = Math.floor((Date.now() - startTime) / 1000);
+  timeEl.textContent = formatTime(elapsedSeconds);
+}
+
+function stopTimer() {
+  if (timerId) {
+    window.clearInterval(timerId);
+    timerId = null;
+  }
+}
+
+function startTimer() {
+  if (timerId) return;
+  startTime = Date.now();
+  updateTimer();
+  timerId = window.setInterval(updateTimer, 1000);
+}
+
+function announce(message) {
+  if (statusEl) {
+    statusEl.textContent = message;
+  }
+}
+
+function resetBoard() {
+  stopTimer();
+  startTime = null;
+  matches = 0;
+  turns = 0;
+  firstCard = null;
+  secondCard = null;
+  lockBoard = false;
+  updateStats();
+  updateTimer();
+  announce('Flip two cards to get started.');
+
+  deck = shuffle([...SYMBOLS, ...SYMBOLS]);
+  boardEl.innerHTML = '';
+  boardEl.setAttribute('aria-label', `Neon memory board with ${deck.length} cards`);
+
+  deck.forEach((symbol, index) => {
+    const cardButton = document.createElement('button');
+    cardButton.type = 'button';
+    cardButton.className = 'memory-card';
+    cardButton.dataset.symbol = symbol;
+    cardButton.dataset.index = index.toString();
+    cardButton.setAttribute('aria-pressed', 'false');
+    cardButton.setAttribute('aria-label', 'Hidden card');
+    cardButton.setAttribute('role', 'gridcell');
+
+    cardButton.innerHTML = `
+      <span class="memory-card__face memory-card__face--back" aria-hidden="true"></span>
+      <span class="memory-card__face memory-card__face--front">${symbol}</span>
+    `;
+
+    cardButton.addEventListener('click', () => onCardSelect(cardButton));
+    boardEl.append(cardButton);
+  });
+}
+
+function lockMatch(cardA, cardB) {
+  cardA.classList.add('is-matched');
+  cardB.classList.add('is-matched');
+  cardA.disabled = true;
+  cardB.disabled = true;
+  cardA.setAttribute('aria-pressed', 'true');
+  cardB.setAttribute('aria-pressed', 'true');
+  cardA.setAttribute('aria-label', `Matched card showing ${cardA.dataset.symbol}`);
+  cardB.setAttribute('aria-label', `Matched card showing ${cardB.dataset.symbol}`);
+
+  matches += 1;
+  updateStats();
+
+  if (matches === deck.length / 2) {
+    stopTimer();
+    const finalTime = timeEl ? timeEl.textContent : '';
+    announce(`Board cleared in ${turns} turns and ${finalTime}. Stellar memory!`);
+  } else {
+    announce('Nice match! Keep the streak going.');
+  }
+
+  firstCard = null;
+  secondCard = null;
+  lockBoard = false;
+}
+
+function hidePair(cardA, cardB) {
+  window.setTimeout(() => {
+    cardA.classList.remove('is-flipped');
+    cardB.classList.remove('is-flipped');
+    cardA.setAttribute('aria-pressed', 'false');
+    cardB.setAttribute('aria-pressed', 'false');
+    cardA.setAttribute('aria-label', 'Hidden card');
+    cardB.setAttribute('aria-label', 'Hidden card');
+    firstCard = null;
+    secondCard = null;
+    lockBoard = false;
+    announce('So close! Keep pairing those icons.');
+  }, 700);
+}
+
+function onCardSelect(card) {
+  if (lockBoard || card === firstCard || card.classList.contains('is-matched')) {
+    return;
+  }
+
+  if (!startTime) {
+    startTimer();
+  }
+
+  card.classList.add('is-flipped');
+  card.setAttribute('aria-pressed', 'true');
+  card.setAttribute('aria-label', `Card showing ${card.dataset.symbol}`);
+
+  if (!firstCard) {
+    firstCard = card;
+    announce('Choose another card to find a match.');
+    return;
+  }
+
+  secondCard = card;
+  lockBoard = true;
+  turns += 1;
+  updateStats();
+
+  if (firstCard.dataset.symbol === secondCard.dataset.symbol) {
+    lockMatch(firstCard, secondCard);
+  } else {
+    hidePair(firstCard, secondCard);
+  }
+}
+
+resetBtn?.addEventListener('click', resetBoard);
+
+resetBoard();

--- a/neon-memory/styles.css
+++ b/neon-memory/styles.css
@@ -1,0 +1,227 @@
+:root {
+  color-scheme: dark;
+}
+
+body {
+  background: radial-gradient(circle at top, rgba(44, 20, 76, 0.9), #050513 72%);
+}
+
+.arcade-main {
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.memory {
+  display: grid;
+  gap: clamp(1.25rem, 2.5vw, 2rem);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  background: rgba(10, 15, 45, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 28px 60px rgba(8, 10, 30, 0.55);
+}
+
+.memory__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(1rem, 3vw, 2.5rem);
+  flex-wrap: wrap;
+}
+
+.memory__intro {
+  max-width: 34ch;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.memory__intro h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+}
+
+.memory__intro p {
+  margin: 0;
+  color: rgba(248, 249, 255, 0.7);
+  font-size: 0.98rem;
+}
+
+.memory__controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.memory__stat {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 14px;
+  background: rgba(14, 24, 64, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(123, 91, 255, 0.1);
+}
+
+.memory__stat .label {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(248, 249, 255, 0.55);
+}
+
+.memory__stat .value {
+  font-size: 1.45rem;
+  font-weight: 600;
+}
+
+.memory__reset {
+  padding: 0.75rem 1.2rem;
+  border-radius: 12px;
+  border: 1px solid rgba(86, 220, 255, 0.5);
+  background: linear-gradient(135deg, rgba(86, 220, 255, 0.15), rgba(147, 128, 255, 0.25));
+  color: #f8f9ff;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  box-shadow: 0 16px 38px rgba(6, 12, 44, 0.45);
+}
+
+.memory__reset:hover,
+.memory__reset:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 44px rgba(6, 12, 44, 0.55);
+  outline: none;
+}
+
+.memory__status {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(248, 249, 255, 0.7);
+}
+
+.memory__board {
+  --card-size: min(120px, 24vw);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--card-size), 1fr));
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  justify-items: center;
+}
+
+.memory-card {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  border: none;
+  border-radius: 18px;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  transform-style: preserve-3d;
+  transition: transform 320ms cubic-bezier(0.22, 0.61, 0.36, 1), box-shadow 320ms ease;
+  box-shadow: 0 18px 42px rgba(6, 12, 40, 0.45);
+}
+
+.memory-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(123, 91, 255, 0.35);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.memory-card:focus-visible {
+  outline: none;
+  box-shadow: 0 20px 48px rgba(40, 86, 255, 0.5);
+}
+
+.memory-card:focus-visible::after {
+  opacity: 1;
+  border-color: rgba(86, 220, 255, 0.75);
+  box-shadow: 0 0 0 6px rgba(86, 220, 255, 0.25);
+}
+
+.memory-card__face {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(2rem, 6vw, 3.4rem);
+  backface-visibility: hidden;
+  background: linear-gradient(140deg, rgba(34, 38, 92, 0.9), rgba(12, 18, 42, 0.9));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.memory-card__face--back {
+  background: linear-gradient(135deg, rgba(123, 91, 255, 0.4), rgba(34, 170, 255, 0.45));
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.35);
+}
+
+.memory-card__face--front {
+  transform: rotateY(180deg);
+  text-shadow: 0 8px 26px rgba(0, 0, 0, 0.4);
+}
+
+.memory-card.is-flipped {
+  transform: rotateY(180deg) scale(1.02);
+}
+
+.memory-card.is-matched {
+  transform: rotateY(180deg) scale(1.04);
+}
+
+.memory-card.is-matched::after {
+  opacity: 1;
+  border-color: rgba(86, 220, 255, 0.85);
+  box-shadow: 0 0 0 8px rgba(86, 220, 255, 0.22);
+}
+
+.memory-help {
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  display: grid;
+  gap: 1rem;
+  background: rgba(10, 15, 45, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 56px rgba(8, 12, 36, 0.5);
+}
+
+.memory-help h2 {
+  margin: 0;
+}
+
+.memory-help ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: rgba(248, 249, 255, 0.75);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.memory-help__tip {
+  margin: 0;
+  color: rgba(86, 220, 255, 0.85);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .memory__controls {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .memory__reset {
+    grid-column: span 2;
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .memory-card,
+  .memory-card::after,
+  .memory__reset {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- revamp the landing hero with a live update ticker, shuffle widget, and highlight effects while adding two new game cards and artwork
- extend the shared arcade script to surface total/new game counts and drive the surprise-me interaction
- add the Neon Memory matching game with bespoke styling, gameplay logic, and thumbnails for the new titles

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d93b266704832c94bf422928c49514