### PR TITLE
Fix initial spawn in Simple Mover and hide Neon Brick Breaker overlay

### DIFF
--- a/brick-breaker-clone/style.css
+++ b/brick-breaker-clone/style.css
@@ -12,6 +12,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   margin: 0;
   min-height: 100vh;


### PR DESCRIPTION
## Summary
- ensure Simple Mover finds a safe player spawn that avoids wall collisions
- add a `[hidden]` rule so the Neon Brick Breaker overlay disappears when dismissed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d94026a334832c9a3cfa009d34f0a8