### PR TITLE
Refactor brick breaker layout for arcade shell

### DIFF
--- a/brick-breaker-clone/index.html
+++ b/brick-breaker-clone/index.html
@@ -4,44 +4,73 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Neon Brick Breaker</title>
+    <link rel="stylesheet" href="../arcade.css" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <main class="game-shell">
-      <header class="hud">
-        <h1>Neon Brick Breaker</h1>
-        <p class="tagline">Break every block, keep the ball alive, and climb the levels.</p>
-        <div class="scoreboard">
-          <div class="score-tile">
-            <span class="label">Score</span>
-            <span class="value" id="score">0</span>
-          </div>
-          <div class="score-tile">
-            <span class="label">Level</span>
-            <span class="value" id="level">1</span>
-          </div>
-          <div class="score-tile">
-            <span class="label">Lives</span>
-            <span class="value" id="lives">3</span>
-          </div>
+    <div class="arcade-page">
+      <header class="arcade-header card-surface">
+        <div class="arcade-header__meta">
+          <span class="brand-title">Pixel Playground</span>
+          <h1>Neon Brick Breaker</h1>
+          <p>Break every block, keep the ball alive, and climb the neon-soaked levels.</p>
         </div>
+        <a class="arcade-back" href="../index.html">
+          <span aria-hidden="true">⟵</span>
+          Back to Arcade
+        </a>
       </header>
 
-      <section class="canvas-stage">
-        <canvas id="gameCanvas" width="900" height="600" aria-label="Brick breaker play field"></canvas>
-        <div class="overlay" id="overlay" hidden>
-          <div class="overlay-card">
-            <h2 id="overlay-title">Ready?</h2>
-            <p id="overlay-message">
-              Use the arrow keys or move your mouse to slide the paddle. Smash every brick without losing all lives.
-            </p>
-            <button type="button" id="overlay-action">Start game</button>
-            <p class="overlay-tip">Press space to pause or resume mid game.</p>
+      <main class="arcade-main">
+        <section class="arcade-game">
+          <div class="arcade-game__frame">
+            <canvas
+              id="gameCanvas"
+              width="960"
+              height="540"
+              aria-label="Brick breaker play field"
+            ></canvas>
+            <div class="overlay" id="overlay" hidden>
+              <div class="overlay-card">
+                <h2 id="overlay-title">Ready?</h2>
+                <p id="overlay-message">
+                  Use the arrow keys or move your mouse to slide the paddle. Smash every brick without losing all lives.
+                </p>
+                <button class="btn overlay-action" type="button" id="overlay-action">Start game</button>
+                <p class="overlay-tip">Press space to pause or resume mid game.</p>
+              </div>
+            </div>
           </div>
-        </div>
-      </section>
-    </main>
+
+          <aside class="arcade-panel hud-panel card-surface">
+            <header class="hud-panel__header">
+              <h2>Cabinet Status</h2>
+              <p class="hud-panel__subtitle">Keep the combo alive to chase the leaderboard.</p>
+            </header>
+            <div class="scoreboard">
+              <div class="score-tile">
+                <span class="label">Score</span>
+                <span class="value" id="score">0</span>
+              </div>
+              <div class="score-tile">
+                <span class="label">Level</span>
+                <span class="value" id="level">1</span>
+              </div>
+              <div class="score-tile">
+                <span class="label">Lives</span>
+                <span class="value" id="lives">3</span>
+              </div>
+            </div>
+          </aside>
+        </section>
+      </main>
+
+      <footer class="arcade-footer">
+        © <span class="js-year"></span> Pixel Playground · The cabinet resets between each run—go earn the glow.
+      </footer>
+    </div>
 
     <script src="script.js"></script>
+    <script src="../assets/js/arcade.js" defer></script>
   </body>
 </html>

--- a/brick-breaker-clone/style.css
+++ b/brick-breaker-clone/style.css
@@ -22,69 +22,24 @@ body {
   font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   background: var(--bg);
   color: #f7fbff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: clamp(1.5rem, 4vw, 3rem);
 }
 
-.game-shell {
-  width: min(1024px, 100%);
+.arcade-page {
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.arcade-main {
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.arcade-game {
   display: grid;
-  gap: clamp(1.5rem, 3vw, 2.6rem);
+  gap: clamp(1.5rem, 3vw, 2rem);
+  align-items: start;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
 }
 
-.hud {
-  background: var(--panel);
-  border: 1px solid var(--panel-border);
-  border-radius: 24px;
-  padding: clamp(1.5rem, 4vw, 2.5rem);
-  box-shadow: 0 24px 64px rgba(6, 10, 35, 0.4);
-  display: grid;
-  gap: 1rem;
-}
-
-.hud h1 {
-  margin: 0;
-  font-size: clamp(2rem, 5vw, 3rem);
-  letter-spacing: 0.04em;
-}
-
-.tagline {
-  margin: 0;
-  font-size: clamp(1rem, 2.4vw, 1.2rem);
-  color: var(--text-dim);
-}
-
-.scoreboard {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-}
-
-.score-tile {
-  flex: 1 1 140px;
-  background: rgba(16, 21, 50, 0.8);
-  border: 1px solid rgba(132, 196, 255, 0.2);
-  border-radius: 18px;
-  padding: 0.85rem 1.1rem;
-  display: grid;
-  gap: 0.35rem;
-}
-
-.score-tile .label {
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.28em;
-  color: rgba(188, 209, 255, 0.6);
-}
-
-.score-tile .value {
-  font-size: 1.6rem;
-  font-weight: 600;
-}
-
-.canvas-stage {
+.arcade-game__frame {
   position: relative;
   border-radius: 24px;
   overflow: hidden;
@@ -97,6 +52,7 @@ canvas {
   display: block;
   width: 100%;
   height: auto;
+  aspect-ratio: 16 / 9;
 }
 
 .overlay {
@@ -138,7 +94,7 @@ canvas {
   color: rgba(210, 226, 255, 0.6);
 }
 
-.overlay button {
+.overlay-action {
   border: none;
   border-radius: 999px;
   padding: 0.75rem 1.8rem;
@@ -147,25 +103,95 @@ canvas {
   cursor: pointer;
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
   color: #0c102a;
+  box-shadow: 0 18px 34px rgba(136, 226, 255, 0.3);
   transition: transform 160ms ease, box-shadow 160ms ease;
 }
 
-.overlay button:hover,
-.overlay button:focus-visible {
+.overlay-action:hover,
+.overlay-action:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 18px 34px rgba(136, 226, 255, 0.4);
+  box-shadow: 0 18px 34px rgba(136, 226, 255, 0.5);
 }
 
-@media (max-width: 720px) {
-  body {
-    padding: 1rem;
+.arcade-panel {
+  display: grid;
+  gap: 1.25rem;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  border-radius: 24px;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 24px 64px rgba(6, 10, 35, 0.4);
+}
+
+.hud-panel__header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.hud-panel__header h2 {
+  margin: 0;
+  font-size: clamp(1.4rem, 3vw, 1.8rem);
+}
+
+.hud-panel__subtitle {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.3vw, 1.1rem);
+  color: var(--text-dim);
+}
+
+.scoreboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.score-tile {
+  background: rgba(16, 21, 50, 0.8);
+  border: 1px solid rgba(132, 196, 255, 0.2);
+  border-radius: 18px;
+  padding: 0.85rem 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.score-tile .label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  color: rgba(188, 209, 255, 0.6);
+}
+
+.score-tile .value {
+  font-size: clamp(1.6rem, 4vw, 2rem);
+  font-weight: 600;
+}
+
+@media (min-width: 840px) {
+  .scoreboard {
+    flex-direction: row;
   }
 
-  .game-shell {
-    gap: 1.5rem;
+  .score-tile {
+    flex: 1 1 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .arcade-game {
+    grid-template-columns: 1fr;
   }
 
-  canvas {
-    height: 70vh;
+  .arcade-panel {
+    order: 2;
+  }
+}
+
+@media (max-width: 600px) {
+  .overlay-card {
+    padding: 1.5rem;
+  }
+
+  .scoreboard {
+    gap: 0.75rem;
   }
 }


### PR DESCRIPTION
## Summary
- integrate the shared arcade shell markup for Neon Brick Breaker and hook up the common assets
- reshape the HUD into an arcade panel and adjust the canvas frame for a 16:9 stage
- tune responsive behavior so overlays and panels stack cleanly on smaller viewports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d94d3d45d8832cbc0563d25b8ab1d3