### PR TITLE
Refactor 2048 page into arcade game layout

### DIFF
--- a/2048/index.html
+++ b/2048/index.html
@@ -22,12 +22,56 @@
       </header>
 
       <main class="arcade-main">
-          <div class="app">
-            <header class="top-bar">
-              <div class="branding">
+        <section class="arcade-game">
+          <div class="arcade-game__stage">
+            <div class="arcade-game__frame">
+              <header class="game-brief">
                 <h2>Merge the numbers</h2>
                 <p>Use arrow keys, WASD, or swipe gestures to slide tiles.</p>
-              </div>
+              </header>
+
+              <section class="board" aria-label="2048 board">
+                <div class="grid">
+                  <div class="grid-row">
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                  </div>
+                  <div class="grid-row">
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                  </div>
+                  <div class="grid-row">
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                  </div>
+                  <div class="grid-row">
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                    <div class="grid-cell"></div>
+                  </div>
+                </div>
+                <div class="tile-container" aria-hidden="true"></div>
+                <div id="message" class="message" role="alert" hidden>
+                  <div class="message-box">
+                    <p id="message-text"></p>
+                    <button id="keep-playing" type="button" class="button button-secondary">Keep Playing</button>
+                  </div>
+                </div>
+              </section>
+            </div>
+          </div>
+
+          <aside class="arcade-game__sidebar">
+            <div class="arcade-panel arcade-panel--score">
+              <h2 class="arcade-panel__title">Scoreboard</h2>
+              <p class="arcade-panel__subtitle">Track your current run and start a new game anytime.</p>
               <div class="scoreboard" role="status" aria-live="polite">
                 <div class="score-block">
                   <span class="label">Score</span>
@@ -37,56 +81,23 @@
                   <span class="label">Best</span>
                   <span id="best" class="value">0</span>
                 </div>
+              </div>
+              <div class="arcade-panel__actions">
                 <button id="reset" type="button" class="button">New Game</button>
               </div>
-            </header>
+            </div>
 
-            <section class="board" aria-label="2048 board">
-              <div class="grid">
-                <div class="grid-row">
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                </div>
-                <div class="grid-row">
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                </div>
-                <div class="grid-row">
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                </div>
-                <div class="grid-row">
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                  <div class="grid-cell"></div>
-                </div>
-              </div>
-              <div class="tile-container" aria-hidden="true"></div>
-              <div id="message" class="message" role="alert" hidden>
-                <div class="message-box">
-                  <p id="message-text"></p>
-                  <button id="keep-playing" type="button" class="button button-secondary">Keep Playing</button>
-                </div>
-              </div>
-            </section>
-
-            <footer class="info">
-              <h2>How to play</h2>
+            <div class="arcade-panel arcade-panel--instructions">
+              <h2 class="arcade-panel__title">How to play</h2>
               <ul>
                 <li><strong>Desktop:</strong> Use arrow keys or WASD to slide tiles.</li>
                 <li><strong>Touch:</strong> Swipe in any direction.</li>
                 <li>Combine tiles with the same number to reach <strong>2048</strong>.</li>
               </ul>
-            </footer>
-          </div>
-        </main>
+            </div>
+          </aside>
+        </section>
+      </main>
 
       <footer class="arcade-footer">
         © <span class="js-year"></span> Pixel Playground · Keep merging to chase higher scores.

--- a/2048/style.css
+++ b/2048/style.css
@@ -1,121 +1,71 @@
 :root {
-  --bg: #f9f5ff;
   --panel: rgba(255, 255, 255, 0.75);
   --panel-border: rgba(137, 97, 255, 0.2);
   --text: #2f234f;
   --accent: #8e7cff;
   --accent-dark: #6b5bdf;
-  --tile-size: min(18vw, 100px);
-  --tile-gap: clamp(0.5rem, 1.5vw, 1rem);
-  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
 }
 
 * {
   box-sizing: border-box;
 }
 
-body {
-  margin: 0;
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: clamp(1.5rem, 4vw, 3rem);
-  background: radial-gradient(circle at top, #f5efff 0%, #f0f4ff 45%, #f9f5ff 100%);
+.arcade-main {
+  align-items: stretch;
+}
+
+.arcade-game {
+  --arcade-stage-width: min(90vw, 640px);
+  --board-padding: clamp(1.25rem, 3vw, 2rem);
+  --tile-gap: clamp(0.5rem, 1.5vw, 1rem);
+  --tile-size: calc(
+    (var(--arcade-stage-width) - 2 * var(--board-padding) - 3 * var(--tile-gap)) / 4
+  );
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  align-items: start;
+  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   color: var(--text);
 }
 
-.arcade-main {
-  align-items: center;
+.arcade-game__stage {
+  padding: clamp(1.5rem, 4vw, 3rem);
+  border-radius: 28px;
+  background: radial-gradient(circle at top, #f5efff 0%, #f0f4ff 45%, #f9f5ff 100%);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 2.5rem 4.5rem rgba(78, 61, 158, 0.18);
 }
 
-.app {
-  width: min(90vw, 640px);
-  padding: clamp(1rem, 3vw, 2.5rem);
-  display: flex;
-  flex-direction: column;
+.arcade-game__frame {
+  width: min(100%, var(--arcade-stage-width));
+  margin: 0 auto;
+  display: grid;
   gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
-.top-bar {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-  background: var(--panel);
-  border: 1px solid var(--panel-border);
-  border-radius: 1.25rem;
-  padding: clamp(1rem, 2vw, 1.5rem);
-  box-shadow: 0 1.25rem 3rem rgba(78, 61, 158, 0.12);
+.game-brief {
+  display: grid;
+  gap: 0.4rem;
+  text-align: center;
 }
 
-.branding h2 {
+.game-brief h2 {
   margin: 0;
   font-size: clamp(2.5rem, 6vw, 3.5rem);
   letter-spacing: 0.08em;
 }
 
-.branding p {
-  margin: 0.35rem 0 0;
+.game-brief p {
+  margin: 0;
   color: rgba(47, 35, 79, 0.7);
-}
-
-.scoreboard {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.score-block {
-  display: grid;
-  gap: 0.25rem;
-  text-align: center;
-  min-width: 92px;
-  padding: 0.5rem 0.75rem;
-  background: rgba(255, 255, 255, 0.9);
-  border-radius: 0.9rem;
-  box-shadow: inset 0 0 0 1px rgba(137, 97, 255, 0.18);
-}
-
-.label {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(47, 35, 79, 0.6);
-}
-
-.value {
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.button {
-  border: none;
-  border-radius: 0.9rem;
-  padding: 0.6rem 1.2rem;
-  font-weight: 600;
-  cursor: pointer;
-  background: linear-gradient(135deg, var(--accent), #b3a8ff);
-  color: white;
-  box-shadow: 0 0.8rem 1.4rem rgba(142, 124, 255, 0.35);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.button:hover,
-.button:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 1rem 2.2rem rgba(142, 124, 255, 0.4);
-}
-
-.button-secondary {
-  background: white;
-  color: var(--accent-dark);
-  box-shadow: inset 0 0 0 1px rgba(142, 124, 255, 0.35);
 }
 
 .board {
   position: relative;
-  padding: clamp(1.25rem, 3vw, 2rem);
+  width: 100%;
+  max-width: var(--arcade-stage-width);
+  margin: 0 auto;
+  padding: var(--board-padding);
   border-radius: 1.75rem;
   background: var(--panel);
   border: 1px solid var(--panel-border);
@@ -124,8 +74,8 @@ body {
 
 .grid {
   position: relative;
+  width: 100%;
   aspect-ratio: 1 / 1;
-  width: calc(var(--tile-size) * 4 + var(--tile-gap) * 3);
   margin: 0 auto;
 }
 
@@ -148,7 +98,7 @@ body {
 
 .tile-container {
   position: absolute;
-  top: clamp(1.25rem, 3vw, 2rem);
+  top: var(--board-padding);
   left: 50%;
   width: calc(var(--tile-size) * 4 + var(--tile-gap) * 3);
   height: calc(var(--tile-size) * 4 + var(--tile-gap) * 3);
@@ -272,7 +222,7 @@ body {
 
 .message {
   position: absolute;
-  inset: clamp(1.25rem, 3vw, 2rem);
+  inset: var(--board-padding);
   display: grid;
   place-items: center;
   background: rgba(249, 245, 255, 0.88);
@@ -290,52 +240,135 @@ body {
   text-align: center;
 }
 
-.info {
+.arcade-game__sidebar {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.arcade-panel {
   background: var(--panel);
   border: 1px solid var(--panel-border);
-  border-radius: 1.25rem;
+  border-radius: 1.5rem;
   padding: clamp(1rem, 2vw, 1.5rem);
   box-shadow: 0 1.25rem 3rem rgba(78, 61, 158, 0.12);
+  display: grid;
+  gap: 1rem;
 }
 
-.info h2 {
-  margin-top: 0;
+.arcade-panel__title {
+  margin: 0;
+  font-size: clamp(1.25rem, 3vw, 1.5rem);
 }
 
-.info ul {
+.arcade-panel__subtitle {
+  margin: 0;
+  color: rgba(47, 35, 79, 0.65);
+  font-size: 0.95rem;
+}
+
+.arcade-panel__actions {
+  display: flex;
+}
+
+.arcade-panel__actions .button {
+  width: auto;
+}
+
+.arcade-panel--instructions ul {
   margin: 0;
   padding-left: 1.2rem;
   color: rgba(47, 35, 79, 0.75);
 }
 
-@media (max-width: 640px) {
-  :root {
-    --tile-size: min(20vw, 78px);
-  }
+.scoreboard {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
 
-  .top-bar {
-    flex-direction: column;
-    align-items: stretch;
+.score-block {
+  display: grid;
+  gap: 0.25rem;
+  text-align: center;
+  min-width: 92px;
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 0.9rem;
+  box-shadow: inset 0 0 0 1px rgba(137, 97, 255, 0.18);
+}
+
+.label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(47, 35, 79, 0.6);
+}
+
+.value {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.button {
+  border: none;
+  border-radius: 0.9rem;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--accent), #b3a8ff);
+  color: white;
+  box-shadow: 0 0.8rem 1.4rem rgba(142, 124, 255, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 1rem 2.2rem rgba(142, 124, 255, 0.4);
+}
+
+.button-secondary {
+  background: white;
+  color: var(--accent-dark);
+  box-shadow: inset 0 0 0 1px rgba(142, 124, 255, 0.35);
+}
+
+@media (min-width: 960px) {
+  .arcade-game {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 320px);
+  }
+}
+
+@media (max-width: 768px) {
+  .arcade-game {
+    --arcade-stage-width: min(100vw - 3rem, 520px);
+  }
+}
+
+@media (max-width: 640px) {
+  .arcade-game {
+    grid-template-columns: minmax(0, 1fr);
+    --arcade-stage-width: min(100vw - 2.5rem, 480px);
   }
 
   .scoreboard {
     width: 100%;
     justify-content: space-between;
-    flex-wrap: wrap;
   }
 
-  .score-block {
-    flex: 1 1 45%;
+  .arcade-panel__actions {
+    width: 100%;
   }
 
-  .button {
+  .arcade-panel__actions .button {
     width: 100%;
   }
 }
 
 @media (max-width: 420px) {
-  :root {
-    --tile-size: min(22vw, 70px);
+  .arcade-game {
+    --arcade-stage-width: min(100vw - 2rem, 440px);
   }
 
   .scoreboard {


### PR DESCRIPTION
## Summary
- nest the 2048 board inside the arcade game stage/frame structure and move the HUD panels into the shared sidebar
- retheme the game CSS to use arcade variables instead of body centering, including the new board sizing token
- tune responsive rules so the scoreboard panel stacks beneath the playfield on mobile without hiding swipe tips

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d94d3b092c832c9c7b6755b37eb35f