### PR TITLE
Refine endless runner layout

### DIFF
--- a/endless-runner/index.html
+++ b/endless-runner/index.html
@@ -22,24 +22,45 @@
       </header>
 
       <main class="arcade-main">
-        <section class="game-shell" aria-labelledby="runner-title">
-          <header class="hud">
-            <h2 id="runner-title" class="game-title">Neon Runner</h2>
-            <div class="scoreboard" role="status" aria-live="polite">
-              <span class="label">Score:</span>
-              <span id="score">0</span>
+        <section class="arcade-game" aria-labelledby="runner-title">
+          <div class="arcade-game__stage card-surface">
+            <div class="arcade-game__frame">
+              <canvas
+                id="game"
+                width="960"
+                height="540"
+                role="img"
+                aria-label="Endless runner game"
+              ></canvas>
             </div>
-          </header>
-          <section class="canvas-wrapper">
-            <canvas id="game" width="960" height="540" role="img" aria-label="Endless runner game"></canvas>
-            <div class="controls-hint" aria-hidden="true">
-              <p>Press <strong>Space</strong> / <strong>Up</strong> to Jump · <strong>Down</strong> to Duck</p>
-              <p>Tap left/right side to Jump/Duck on touch</p>
-            </div>
-          </section>
-          <footer class="hud">
-            <button id="restart" type="button" class="hidden">Restart</button>
-          </footer>
+          </div>
+
+          <aside class="arcade-game__sidebar">
+            <article class="arcade-panel card-surface hud-card" role="status" aria-live="polite">
+              <h2 id="runner-title" class="hud-card__title">Neon Runner</h2>
+              <p class="hud-card__subtitle">
+                Leap, duck, and dash through synthwave streets while pushing your high score higher.
+              </p>
+              <div class="hud-stat">
+                <span class="hud-stat__label">Score</span>
+                <span id="score" class="hud-stat__value">0</span>
+              </div>
+            </article>
+
+            <article class="arcade-panel card-surface">
+              <h3 class="hud-card__title">Controls</h3>
+              <p class="hud-text">
+                Press <strong>Space</strong> or <strong>Up</strong> to jump and <strong>Down</strong> to duck.
+              </p>
+              <p class="hud-text">Tap left to jump or right to duck on touch screens.</p>
+            </article>
+
+            <article class="arcade-panel card-surface">
+              <h3 class="hud-card__title">Session</h3>
+              <p class="hud-text">Start a fresh run whenever you wipe out.</p>
+              <button id="restart" type="button" class="hud-button hidden">Restart</button>
+            </article>
+          </aside>
         </section>
       </main>
 

--- a/endless-runner/style.css
+++ b/endless-runner/style.css
@@ -1,132 +1,192 @@
 :root {
   color-scheme: dark;
-  --bg: #05020f;
-  --bg-secondary: #100a27;
-  --accent: #ff2bd6;
-  --accent-secondary: #39ff14;
-  --text: #f8f7ff;
-  --shadow: rgba(255, 43, 214, 0.4);
+  --arcade-stage-width: 960px;
+  --runner-surface: linear-gradient(180deg, rgba(16, 10, 39, 0.95), rgba(5, 2, 15, 0.92));
+  --runner-border: rgba(255, 43, 214, 0.55);
+  --runner-border-soft: rgba(255, 43, 214, 0.25);
+  --runner-highlight: #39ff14;
+  --runner-text: #f8f7ff;
   font-family: "Press Start 2P", "Segoe UI", sans-serif;
 }
 
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+body {
+  background:
+    radial-gradient(circle at top, rgba(57, 255, 20, 0.2), transparent 55%),
+    radial-gradient(circle at bottom, rgba(255, 43, 214, 0.22), transparent 60%),
+    #05020f;
+  color: var(--runner-text);
 }
 
-body {
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: radial-gradient(circle at top, rgba(57, 255, 20, 0.2), transparent 55%),
-    radial-gradient(circle at bottom, rgba(255, 43, 214, 0.2), transparent 60%), var(--bg);
-  color: var(--text);
-  padding: clamp(1rem, 3vw, 2.5rem);
+.arcade-page {
+  width: min(1280px, 100%);
 }
 
 .arcade-main {
-  align-items: center;
+  align-items: stretch;
 }
 
-.game-shell {
-  width: min(960px, 100%);
-  background: linear-gradient(180deg, rgba(16, 10, 39, 0.95), rgba(5, 2, 15, 0.95));
-  border: 2px solid var(--accent);
-  border-radius: 18px;
-  box-shadow: 0 1.5rem 3rem rgba(5, 2, 15, 0.8), 0 0 1rem var(--shadow);
-  overflow: hidden;
+.arcade-game {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  align-items: start;
+}
+
+.arcade-game__stage {
+  padding: clamp(1.1rem, 3vw, 1.75rem);
+  background: var(--runner-surface);
+  border-radius: 20px;
+  border: 1px solid var(--runner-border-soft);
+  box-shadow: 0 1.5rem 3.5rem rgba(5, 2, 15, 0.75), 0 0 1.35rem rgba(255, 43, 214, 0.2);
   display: flex;
-  flex-direction: column;
+  justify-content: center;
+}
+
+.arcade-game__frame {
+  width: min(var(--arcade-stage-width), 100%);
+  border-radius: 16px;
+  border: 1px solid var(--runner-border);
+  box-shadow: 0 1.25rem 2.75rem rgba(5, 2, 15, 0.7), 0 0 1.2rem rgba(57, 255, 20, 0.35);
+  background: linear-gradient(180deg, #12062b 0%, #04010e 100%);
+  overflow: hidden;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.arcade-game__sidebar {
+  display: grid;
+  gap: clamp(1rem, 2.4vw, 1.6rem);
+}
+
+.arcade-panel {
+  display: grid;
+  gap: 0.75rem;
+  padding: clamp(1rem, 2.4vw, 1.5rem);
+  background: rgba(12, 14, 40, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 18px;
+  box-shadow: 0 1.5rem 3rem rgba(8, 6, 24, 0.6);
+}
+
+.hud-card {
   gap: 1rem;
 }
 
-.hud {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 1.5rem;
+.hud-card__title {
+  margin: 0;
+  font-size: clamp(1.1rem, 2.6vw, 1.5rem);
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  letter-spacing: 0.12rem;
 }
 
-.game-title {
-  font-size: clamp(1.1rem, 2vw, 1.75rem);
-  text-shadow: 0 0 0.5rem var(--accent), 0 0 1rem rgba(57, 255, 20, 0.5);
+.hud-card__subtitle {
+  margin: 0;
+  font-size: clamp(0.85rem, 2.4vw, 1rem);
+  line-height: 1.6;
+  color: rgba(248, 247, 255, 0.75);
 }
 
-.scoreboard {
+.hud-text {
+  margin: 0;
+  font-size: clamp(0.85rem, 2.2vw, 0.95rem);
+  line-height: 1.6;
+  color: rgba(248, 247, 255, 0.8);
+}
+
+.hud-text strong {
+  color: var(--runner-highlight);
+}
+
+.hud-stat {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  font-size: clamp(0.85rem, 2vw, 1.1rem);
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid var(--runner-border-soft);
+  background: rgba(8, 5, 20, 0.7);
+  box-shadow: inset 0 0 1.25rem rgba(255, 43, 214, 0.08);
 }
 
-.canvas-wrapper {
-  position: relative;
-  padding: 0 1.5rem 1.5rem;
+.hud-stat__label {
+  font-size: clamp(0.75rem, 2vw, 0.85rem);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(248, 247, 255, 0.65);
 }
 
-#game {
-  width: 100%;
-  background: linear-gradient(180deg, #12062b 0%, #04010e 100%);
-  border: 2px solid rgba(255, 43, 214, 0.4);
-  border-radius: 12px;
-  display: block;
+.hud-stat__value {
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  color: var(--runner-highlight);
 }
 
-.controls-hint {
-  position: absolute;
-  left: 50%;
-  bottom: 1.75rem;
-  transform: translateX(-50%);
-  text-align: center;
-  font-size: clamp(0.6rem, 1.5vw, 0.85rem);
-  color: rgba(248, 247, 255, 0.7);
-  text-shadow: 0 0 0.5rem rgba(57, 255, 20, 0.7);
-  pointer-events: none;
-}
-
-.controls-hint strong {
-  color: var(--accent-secondary);
-}
-
-button {
+.hud-button {
   font: inherit;
-  color: var(--text);
-  padding: 0.6rem 1.25rem;
+  font-size: clamp(0.85rem, 2.2vw, 1rem);
+  color: var(--runner-text);
+  padding: 0.75rem 1.75rem;
   border-radius: 999px;
-  border: 2px solid var(--accent);
-  background: transparent;
+  border: 1px solid var(--runner-border);
+  background: linear-gradient(135deg, rgba(255, 43, 214, 0.25), rgba(57, 255, 20, 0.2));
   cursor: pointer;
-  transition: transform 150ms ease, box-shadow 150ms ease;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
 }
 
-button:hover,
-button:focus-visible {
+.hud-button:hover,
+.hud-button:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 0 0.75rem var(--accent), 0 0 1.25rem rgba(57, 255, 20, 0.4);
+  border-color: rgba(255, 43, 214, 0.8);
+  box-shadow: 0 0 1.2rem rgba(255, 43, 214, 0.35), 0 0 1.6rem rgba(57, 255, 20, 0.35);
+  outline: none;
 }
 
-button.hidden {
+.hud-button.hidden {
   display: none;
 }
 
+@media (min-width: 1080px) {
+  .arcade-game {
+    grid-template-columns: minmax(0, var(--arcade-stage-width)) minmax(0, 320px);
+    justify-content: center;
+  }
+}
+
+@media (max-width: 960px) {
+  .arcade-game__stage {
+    padding: clamp(0.9rem, 4vw, 1.4rem);
+  }
+
+  .arcade-panel {
+    padding: clamp(0.85rem, 4vw, 1.25rem);
+  }
+}
+
 @media (max-width: 720px) {
-  body {
-    padding: 0.5rem;
+  .arcade-page {
+    padding: clamp(1rem, 4vw, 1.5rem);
   }
 
-  .game-shell {
-    gap: 0.5rem;
+  .arcade-game {
+    gap: clamp(1.25rem, 5vw, 1.75rem);
   }
 
-  .hud {
-    padding: 0.75rem 1rem;
+  .hud-button {
+    width: 100%;
+    justify-self: start;
+  }
+}
+
+@media (max-width: 540px) {
+  .hud-card__subtitle,
+  .hud-text {
+    font-size: 0.95rem;
   }
 
-  .controls-hint {
-    bottom: 1.25rem;
+  .arcade-panel {
+    gap: 0.85rem;
   }
 }


### PR DESCRIPTION
## Summary
- restructure the endless runner page to use the arcade frame/sidebar layout and move HUD content into reusable panels
- refresh the HUD styling with the shared card helpers, expose the stage width variable, and brighten the new neon stat display
- update responsive rules so the sidebar stacks cleanly on small screens and the controls and restart button stay legible

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d94d423520832cbe2cb58dbe51d40b