### PR TITLE
Refresh thumbnails and add Petak to arcade

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A collection of bite-sized JavaScript arcade games wrapped in a unified retro ae
 | [Endless Runner](./endless-runner/) | Action | Dash through synthwave streets, avoiding obstacles to extend your run. |
 | [Simple Mover](./simple_mover/) | Arcade trainer | Collect stars, dash through gaps, and dodge reactive walls. |
 | [Block Drop](./tetris_knockoff/) | Falling blocks | Rotate and stack tetrominoes to clear lines and level up. |
+| [Petak](./petak/) | Word puzzle | Guess the hidden Serbian five-letter word with adaptive neon hints. |
 
 ## Running locally
 

--- a/assets/thumbnails/2048.svg
+++ b/assets/thumbnails/2048.svg
@@ -1,13 +1,43 @@
 <svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="grad2048" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#f7b733"/>
-      <stop offset="100%" stop-color="#fc4a1a"/>
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#141a4f" />
+      <stop offset="1" stop-color="#251251" />
+    </linearGradient>
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8ae0ff" />
+      <stop offset="1" stop-color="#c287ff" />
+    </linearGradient>
+    <linearGradient id="c" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1b2b74" stop-opacity=".85" />
+      <stop offset="1" stop-color="#0a0d28" stop-opacity=".85" />
+    </linearGradient>
+    <linearGradient id="d" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffe2a8" />
+      <stop offset="1" stop-color="#ff9b55" />
+    </linearGradient>
+    <linearGradient id="e" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fff4ce" />
+      <stop offset="1" stop-color="#ffbe66" />
     </linearGradient>
   </defs>
-  <rect x="0" y="0" width="160" height="120" rx="16" fill="url(#grad2048)"/>
-  <g fill="#fff" font-family="'Poppins', sans-serif" font-weight="700" text-anchor="middle">
-    <text x="80" y="60" font-size="48">2048</text>
-    <text x="80" y="90" font-size="14">Swipe &amp; merge</text>
+  <rect width="160" height="120" rx="20" fill="url(#a)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="#0b102b" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="url(#c)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="none" stroke="url(#b)" stroke-width="1.4" />
+  <g transform="translate(40 26)" fill="#182055">
+    <rect width="32" height="32" rx="7" fill="#1d2a67" />
+    <rect x="36" width="32" height="32" rx="7" fill="#1a2760" />
+    <rect y="36" width="32" height="32" rx="7" fill="#1a2661" />
+    <rect x="36" y="36" width="32" height="32" rx="7" fill="url(#d)" />
+    <rect x="19" y="-10" width="30" height="10" rx="4" fill="#222f7b" opacity=".65" />
+    <rect x="55" y="26" width="22" height="8" rx="4" fill="#fff" opacity=".18" />
   </g>
+  <g fill="#fff" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="700" text-anchor="middle">
+    <text x="92" y="65" font-size="24" fill="#ffe7b7">2048</text>
+    <text x="92" y="83" font-size="10" fill="#f6b574">CHAIN COMBO</text>
+    <text x="92" y="98" font-size="9" fill="#7bd4ff" letter-spacing=".3em">MERGE</text>
+  </g>
+  <rect x="80" y="44" width="48" height="32" rx="8" fill="url(#e)" transform="rotate(-6 80 44)" />
+  <text x="103" y="66" font-family="'Space Grotesk', 'Poppins', sans-serif" font-size="20" font-weight="700" fill="#b34d00" transform="rotate(-6 103 66)">2048</text>
 </svg>

--- a/assets/thumbnails/block-drop.svg
+++ b/assets/thumbnails/block-drop.svg
@@ -1,31 +1,61 @@
 <svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="gradBlock" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1e3a8a"/>
-      <stop offset="100%" stop-color="#9333ea"/>
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#151c55" />
+      <stop offset="1" stop-color="#2d145a" />
     </linearGradient>
-    <linearGradient id="piece" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38f9d7"/>
-      <stop offset="100%" stop-color="#06b6d4"/>
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#88dcff" />
+      <stop offset="1" stop-color="#c98cff" />
     </linearGradient>
-    <linearGradient id="ghost" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.65"/>
-      <stop offset="100%" stop-color="#f0abfc" stop-opacity="0.35"/>
+    <linearGradient id="c" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1a2b73" />
+      <stop offset="1" stop-color="#080e28" />
+    </linearGradient>
+    <linearGradient id="d" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7bffdf" />
+      <stop offset="1" stop-color="#5f9fff" />
+    </linearGradient>
+    <linearGradient id="e" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffefb5" />
+      <stop offset="1" stop-color="#ffa864" />
+    </linearGradient>
+    <linearGradient id="f" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7d8eff" />
+      <stop offset="1" stop-color="#66d2ff" />
     </linearGradient>
   </defs>
-  <rect x="0" y="0" width="160" height="120" rx="16" fill="url(#gradBlock)"/>
-  <g transform="translate(44 20)">
-    <rect x="56" y="4" width="20" height="60" rx="4" fill="url(#ghost)"/>
-    <g fill="url(#piece)" stroke="#ecfeff" stroke-width="2">
-      <rect x="20" y="16" width="20" height="20" rx="3"/>
-      <rect x="40" y="16" width="20" height="20" rx="3"/>
-      <rect x="40" y="36" width="20" height="20" rx="3"/>
-      <rect x="60" y="36" width="20" height="20" rx="3"/>
+  <rect width="160" height="120" rx="20" fill="url(#a)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="#080f28" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="url(#c)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="none" stroke="url(#b)" stroke-width="1.4" />
+  <g transform="translate(34 22)">
+    <rect width="92" height="76" rx="12" fill="#0f163a" />
+    <rect x="6" y="6" width="80" height="64" rx="10" fill="#19245d" />
+    <g opacity=".45" stroke="#25338a" stroke-width="2">
+      <path d="M6 22h80" />
+      <path d="M6 38h80" />
+      <path d="M6 54h80" />
+      <path d="M22 6v64" />
+      <path d="M38 6v64" />
+      <path d="M54 6v64" />
+      <path d="M70 6v64" />
     </g>
-    <g fill="none" stroke="rgba(236, 254, 255, 0.35)" stroke-width="2">
-      <rect x="0" y="76" width="72" height="20" rx="4"/>
-      <rect x="24" y="96" width="72" height="20" rx="4"/>
-    </g>
+    <rect x="38" y="-12" width="24" height="24" rx="6" fill="url(#d)" transform="rotate(8 50 0)" />
+    <rect x="22" y="16" width="16" height="16" rx="4" fill="url(#e)" />
+    <rect x="38" y="16" width="16" height="16" rx="4" fill="#1d285f" opacity=".6" />
+    <rect x="54" y="16" width="16" height="16" rx="4" fill="#1d285f" opacity=".6" />
+    <rect x="70" y="16" width="16" height="16" rx="4" fill="#1d285f" opacity=".6" />
+    <rect x="22" y="32" width="16" height="16" rx="4" fill="url(#f)" />
+    <rect x="38" y="32" width="16" height="16" rx="4" fill="url(#d)" />
+    <rect x="54" y="32" width="16" height="16" rx="4" fill="#1d285f" opacity=".6" />
+    <rect x="70" y="32" width="16" height="16" rx="4" fill="#1d285f" opacity=".6" />
+    <rect x="38" y="48" width="16" height="16" rx="4" fill="url(#e)" />
+    <rect x="54" y="48" width="16" height="16" rx="4" fill="url(#f)" />
+    <rect x="70" y="48" width="16" height="16" rx="4" fill="url(#d)" />
+    <path d="M70 8l10-10" stroke="#ffb165" stroke-width="3" stroke-linecap="round" opacity=".7" />
   </g>
-  <text x="24" y="104" font-family="'Poppins', sans-serif" font-weight="600" font-size="14" fill="#f8fafc">STACK &amp; CLEAR</text>
+  <path d="M32 98c26-12 70-12 96 0" stroke="#7bd4ff" stroke-width="3" stroke-linecap="round" opacity=".55" />
+  <circle cx="54" cy="94" r="6" fill="#ffb264" />
+  <circle cx="106" cy="94" r="6" fill="#67d1ff" />
 </svg>

--- a/assets/thumbnails/brick-breaker.svg
+++ b/assets/thumbnails/brick-breaker.svg
@@ -1,39 +1,50 @@
-<svg width="400" height="300" viewBox="0 0 400 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="bb-bg" x1="200" y1="0" x2="200" y2="300" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#070B2D" />
-      <stop offset="0.5" stop-color="#101B4C" />
-      <stop offset="1" stop-color="#08091E" />
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#161d57" />
+      <stop offset="1" stop-color="#2f165d" />
     </linearGradient>
-    <linearGradient id="bb-paddle" x1="140" y1="228" x2="260" y2="228" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#7DFBFF" />
-      <stop offset="1" stop-color="#F98BFF" />
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#86daff" />
+      <stop offset="1" stop-color="#c88cff" />
     </linearGradient>
-    <linearGradient id="bb-brick" x1="0" y1="0" x2="0" y2="28" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#FFFFFF" stop-opacity="0.9" />
-      <stop offset="0.4" stop-color="#7DFBFF" />
-      <stop offset="1" stop-color="#19245D" />
+    <linearGradient id="c" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1c2b76" />
+      <stop offset="1" stop-color="#090e29" />
+    </linearGradient>
+    <linearGradient id="d" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffefb5" />
+      <stop offset="1" stop-color="#ffb25f" />
+    </linearGradient>
+    <linearGradient id="e" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7bffdf" />
+      <stop offset="1" stop-color="#5f9fff" />
     </linearGradient>
   </defs>
-  <rect width="400" height="300" rx="28" fill="url(#bb-bg)" />
-  <g opacity="0.3" stroke="#6E82F7" stroke-width="1">
-    <path d="M40 80H360" />
-    <path d="M40 120H360" />
-    <path d="M40 160H360" />
-    <path d="M40 200H360" />
+  <rect width="160" height="120" rx="20" fill="url(#a)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="#080f28" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="url(#c)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="none" stroke="url(#b)" stroke-width="1.4" />
+  <g transform="translate(28 26)">
+    <rect width="104" height="20" rx="8" fill="#101641" />
+    <rect x="4" y="4" width="30" height="12" rx="5" fill="#7d8eff" />
+    <rect x="38" y="4" width="30" height="12" rx="5" fill="#ffa162" />
+    <rect x="72" y="4" width="28" height="12" rx="5" fill="#66d0ff" />
+    <rect x="16" y="8" width="16" height="4" rx="2" fill="#fff" opacity=".35" />
+    <rect x="50" y="8" width="16" height="4" rx="2" fill="#fff" opacity=".35" />
+    <rect x="84" y="8" width="14" height="4" rx="2" fill="#fff" opacity=".35" />
   </g>
-  <g transform="translate(80 60)" stroke="#D9E2FF" stroke-opacity="0.6" stroke-width="1.4">
-    <rect width="60" height="26" rx="10" fill="url(#bb-brick)" />
-    <rect x="70" width="60" height="26" rx="10" fill="url(#bb-brick)" />
-    <rect x="140" width="60" height="26" rx="10" fill="url(#bb-brick)" />
-    <rect x="210" width="60" height="26" rx="10" fill="url(#bb-brick)" />
-    <rect x="0" y="36" width="60" height="26" rx="10" fill="url(#bb-brick)" />
-    <rect x="70" y="36" width="60" height="26" rx="10" fill="url(#bb-brick)" />
-    <rect x="140" y="36" width="60" height="26" rx="10" fill="url(#bb-brick)" />
-    <rect x="210" y="36" width="60" height="26" rx="10" fill="url(#bb-brick)" />
+  <g transform="translate(32 56)">
+    <rect width="96" height="14" rx="7" fill="#131a45" />
+    <rect x="6" y="2" width="84" height="10" rx="5" fill="#1f2c6a" />
+    <rect x="36" y="-6" width="24" height="24" rx="12" fill="url(#d)" />
+    <path d="M48 18c26 4 52 16 66 34" stroke="url(#e)" stroke-width="4" stroke-linecap="round" opacity=".6" />
   </g>
-  <rect x="140" y="228" width="120" height="18" rx="10" fill="url(#bb-paddle)" stroke="rgba(255,255,255,0.4)" stroke-width="2" />
-  <circle cx="210" cy="210" r="12" fill="#E9FCFF" stroke="#A6C8FF" stroke-width="2" />
-  <circle cx="210" cy="210" r="6" fill="#7AD8FF" />
-  <circle cx="210" cy="210" r="3" fill="#FFFFFF" />
+  <g transform="translate(20 72)">
+    <rect width="120" height="22" rx="11" fill="#0d122f" />
+    <rect x="4" y="4" width="112" height="14" rx="7" fill="#1b265d" />
+    <rect x="42" y="8" width="36" height="6" rx="3" fill="#7bd4ff" />
+    <rect x="42" y="10" width="36" height="2" rx="1" fill="#fff" opacity=".3" />
+  </g>
+  <path d="M42 98h76" stroke="#ffb265" stroke-width="3" stroke-linecap="round" opacity=".55" />
 </svg>

--- a/assets/thumbnails/connect-four.svg
+++ b/assets/thumbnails/connect-four.svg
@@ -1,19 +1,65 @@
 <svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="gradConnect" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#6a11cb"/>
-      <stop offset="100%" stop-color="#2575fc"/>
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#171e58" />
+      <stop offset="1" stop-color="#2e155c" />
+    </linearGradient>
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8ce4ff" />
+      <stop offset="1" stop-color="#cf91ff" />
+    </linearGradient>
+    <linearGradient id="c" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1c2d7c" />
+      <stop offset="1" stop-color="#090e27" />
+    </linearGradient>
+    <linearGradient id="d" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffd45f" />
+      <stop offset="1" stop-color="#ff8a66" />
+    </linearGradient>
+    <linearGradient id="e" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7d8eff" />
+      <stop offset="1" stop-color="#67d0ff" />
+    </linearGradient>
+    <linearGradient id="f" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffefb5" />
+      <stop offset="1" stop-color="#ffb15d" />
     </linearGradient>
   </defs>
-  <rect x="0" y="0" width="160" height="120" rx="16" fill="url(#gradConnect)"/>
-  <g fill="#fff">
-    <rect x="32" y="24" width="96" height="72" rx="12" opacity="0.3"/>
-    <circle cx="56" cy="42" r="10" opacity="0.9"/>
-    <circle cx="82" cy="42" r="10" opacity="0.6"/>
-    <circle cx="108" cy="42" r="10" opacity="0.9"/>
-    <circle cx="56" cy="66" r="10" opacity="0.6"/>
-    <circle cx="82" cy="66" r="10" opacity="0.9"/>
-    <circle cx="108" cy="66" r="10" opacity="0.6"/>
+  <rect width="160" height="120" rx="20" fill="url(#a)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="#090f28" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="url(#c)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="none" stroke="url(#b)" stroke-width="1.4" />
+  <g transform="translate(32 24)">
+    <rect width="96" height="72" rx="12" fill="#10163d" />
+    <rect x="4" y="4" width="88" height="64" rx="10" fill="#18225a" />
+    <g fill="#070b22" opacity=".5">
+      <rect x="6" y="6" width="84" height="60" rx="8" />
+    </g>
+    <g transform="translate(14 12)" fill="none" stroke="#25348b" stroke-width="2" stroke-linecap="round">
+      <path d="M0 0h68" opacity=".45" />
+      <path d="M0 16h68" opacity=".45" />
+      <path d="M0 32h68" opacity=".45" />
+      <path d="M0 48h68" opacity=".45" />
+      <path d="M0 64h68" opacity=".45" />
+      <path d="M0 0v64" opacity=".45" />
+      <path d="M17 0v64" opacity=".45" />
+      <path d="M34 0v64" opacity=".45" />
+      <path d="M51 0v64" opacity=".45" />
+      <path d="M68 0v64" opacity=".45" />
+    </g>
+    <g transform="translate(14 12)">
+      <circle cx="17" cy="16" r="9" fill="url(#d)" />
+      <circle cx="34" cy="32" r="9" fill="url(#e)" />
+      <circle cx="51" cy="48" r="9" fill="url(#d)" />
+      <circle cx="68" cy="48" r="9" fill="url(#e)" />
+      <circle cx="34" cy="48" r="9" fill="#202f7a" opacity=".65" />
+      <circle cx="51" cy="16" r="9" fill="url(#e)" />
+      <circle cx="68" cy="16" r="9" fill="#1b265d" opacity=".45" />
+      <circle cx="17" cy="32" r="9" fill="#1b265d" opacity=".45" />
+    </g>
+    <path d="M14 55l20-20 20 20 20-20 12 12" fill="none" stroke="url(#f)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
   </g>
-  <text x="80" y="104" font-size="16" fill="#fff" font-family="'Poppins', sans-serif" font-weight="600" text-anchor="middle">Line up four</text>
+  <path d="M28 94h104" stroke="#7bd4ff" stroke-width="3" stroke-linecap="round" opacity=".5" />
+  <circle cx="46" cy="92" r="6" fill="#ffd469" />
+  <circle cx="114" cy="92" r="6" fill="#7ba5ff" />
 </svg>

--- a/assets/thumbnails/endless-runner.svg
+++ b/assets/thumbnails/endless-runner.svg
@@ -1,12 +1,56 @@
 <svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="gradRunner" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#11998e"/>
-      <stop offset="100%" stop-color="#38ef7d"/>
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#131a4e" />
+      <stop offset="1" stop-color="#2a145a" />
     </linearGradient>
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#88dbff" />
+      <stop offset="1" stop-color="#c88bff" />
+    </linearGradient>
+    <linearGradient id="c" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1b2c77" />
+      <stop offset="1" stop-color="#090e29" />
+    </linearGradient>
+    <linearGradient id="d" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7bffdf" />
+      <stop offset="1" stop-color="#5f9fff" />
+    </linearGradient>
+    <linearGradient id="e" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffedb3" />
+      <stop offset="1" stop-color="#ffa35d" />
+    </linearGradient>
+    <radialGradient id="f" cx="0" cy="0" r="1" gradientTransform="translate(118 32) scale(32)">
+      <stop offset="0" stop-color="#ffeab0" />
+      <stop offset="1" stop-color="#ffaf66" stop-opacity="0" />
+    </radialGradient>
   </defs>
-  <rect x="0" y="0" width="160" height="120" rx="16" fill="url(#gradRunner)"/>
-  <path d="M40 90 L70 70 L90 78 L110 60 L130 72" stroke="#fff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-  <circle cx="70" cy="54" r="12" fill="#fff" opacity="0.8"/>
-  <text x="80" y="104" font-size="16" fill="#fff" font-family="'Poppins', sans-serif" font-weight="600" text-anchor="middle">Keep running</text>
+  <rect width="160" height="120" rx="20" fill="url(#a)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="#080f28" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="url(#c)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="none" stroke="url(#b)" stroke-width="1.4" />
+  <circle cx="118" cy="32" r="32" fill="url(#f)" />
+  <g fill="#11183d" opacity=".55">
+    <path d="M18 86h30v16H18z" />
+    <path d="M116 90h28v12h-28z" />
+    <path d="M64 88h22v14H64z" />
+  </g>
+  <g fill="#1b255f" opacity=".65">
+    <path d="M34 54h12v20H34z" />
+    <path d="M52 50h10v24H52z" />
+    <path d="M68 46h14v28H68z" />
+    <path d="M90 52h12v22H90z" />
+    <path d="M110 48h10v26h-10z" />
+  </g>
+  <path d="M34 78h88" stroke="#283690" stroke-width="3" stroke-linecap="round" opacity=".65" />
+  <g transform="translate(52 40)">
+    <path d="M38 12c4.4 0 8 3.6 8 8v10c0 2.2-1.8 4-4 4h-8l-8 12H4l-4-12 8-6V22c0-5.5 4.5-10 10-10z" fill="#121942" />
+    <path d="M16 34l-6 4 3.5 10H8l-3.3-9.8A6 6 0 0 1 10 30z" fill="#7d8eff" />
+    <path d="M30 10c5.5 0 10 4.5 10 10v4c0 3.3-2.7 6-6 6h-8c-3.3 0-6-2.7-6-6v-4c0-5.5 4.5-10 10-10z" fill="url(#e)" />
+    <path d="M34 28l6 10-6 10h-8l4-8-4-12z" fill="#7bffdf" opacity=".8" />
+    <circle cx="36" cy="20" r="2.5" fill="#2a1458" />
+    <path d="M24 46l6 18h-8l-6-18z" fill="#5f9fff" />
+  </g>
+  <path d="M26 98h108" stroke="url(#d)" stroke-width="4" stroke-linecap="round" />
+  <path d="M26 100c28-12 80-12 108 0" stroke="#ffb165" stroke-width="2" stroke-linecap="round" opacity=".65" />
 </svg>

--- a/assets/thumbnails/flappy-bird.svg
+++ b/assets/thumbnails/flappy-bird.svg
@@ -1,16 +1,57 @@
 <svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="gradFlappy" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#4facfe"/>
-      <stop offset="100%" stop-color="#00f2fe"/>
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#151b52" />
+      <stop offset="1" stop-color="#2a1458" />
+    </linearGradient>
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8be2ff" />
+      <stop offset="1" stop-color="#c990ff" />
+    </linearGradient>
+    <radialGradient id="c" cx="0" cy="0" r="1" gradientTransform="translate(118 34) scale(28)">
+      <stop offset="0" stop-color="#ffe6ad" />
+      <stop offset="1" stop-color="#ffab63" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="d" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1c2b76" />
+      <stop offset="1" stop-color="#0b0f29" />
+    </linearGradient>
+    <linearGradient id="e" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7bffdf" />
+      <stop offset="1" stop-color="#5f9fff" />
+    </linearGradient>
+    <linearGradient id="f" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffeab2" />
+      <stop offset="1" stop-color="#ffaf6b" />
     </linearGradient>
   </defs>
-  <rect x="0" y="0" width="160" height="120" rx="16" fill="url(#gradFlappy)"/>
-  <g stroke="#fff" stroke-width="4" stroke-linecap="round" fill="none">
-    <path d="M40 70 Q60 40 80 60 T120 50"/>
-    <circle cx="70" cy="55" r="12" fill="#ffd166" stroke="none"/>
-    <circle cx="74" cy="52" r="4" fill="#1d3557" stroke="none"/>
-    <polyline points="62,55 56,60 60,66" stroke="#ef476f" fill="none" stroke-width="3"/>
+  <rect width="160" height="120" rx="20" fill="url(#a)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="#091029" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="url(#d)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="none" stroke="url(#b)" stroke-width="1.4" />
+  <circle cx="118" cy="34" r="28" fill="url(#c)" />
+  <g fill="#111a45" opacity=".65">
+    <path d="M26 86h24v18H26z" />
+    <path d="M120 90h20v14h-20z" />
+    <path d="M58 92h22v12H58z" />
   </g>
-  <text x="80" y="100" font-size="16" fill="#fff" font-family="'Poppins', sans-serif" font-weight="600" text-anchor="middle">Tap to fly</text>
+  <g transform="translate(36 28)">
+    <path d="M3 0h18c3 0 5 2 5 5v46c0 3-2 5-5 5H3c-1.7 0-3-1.3-3-3V3c0-1.7 1.3-3 3-3z" fill="#10163d" />
+    <rect x="3" y="6" width="18" height="40" rx="4" fill="#1f2f7c" />
+    <rect x="5" y="8" width="14" height="12" rx="3" fill="url(#e)" />
+    <rect x="5" y="30" width="14" height="12" rx="3" fill="url(#e)" transform="scale(1 -1) translate(0 -72)" />
+    <rect x="5" y="20" width="14" height="8" rx="3" fill="#9c7bff" opacity=".55" />
+  </g>
+  <g transform="translate(78 38)">
+    <path d="M18 0c9.9 0 18 8.1 18 18s-8.1 18-18 18c-2.2 0-4.3-.4-6.3-1.2L4 38c-2.2-.9-3.5-3.3-3-5.7l1.6-7.5C1.5 22.6 0 21 0 19c0-2.2 2.1-4 4.7-4h4.2c1.4-5.9 6.8-10 13.1-10z" fill="url(#f)" />
+    <path d="M32 24c-2.2 5.1-6.7 8.6-12 9.4l3.4 6c.5.8-.1 1.8-1.1 1.8H19l-3-4.8" fill="#ffcc7a" opacity=".65" />
+    <circle cx="23.5" cy="17.5" r="2.8" fill="#2a1458" />
+    <path d="M31 16c1.8 0 3.5 1.4 3.7 3.2.3 2.6-2 4.6-4.5 4.1l-6.2-1.3c-.7-.2-.9-1.1-.4-1.6 1.6-1.9 3.8-4.4 5-4.4z" fill="#ff8d5b" />
+    <path d="M13 17c2.2 0 4 1.8 4 4 0 2.9-2.2 5.4-5.1 5.9l-5.6.9c-1.1.2-2.1-.8-1.9-1.9l.8-4.1C6.8 19.1 9.8 17 13 17z" fill="#fff" opacity=".35" />
+  </g>
+  <path d="M108 44h20c1.7 0 3 1.3 3 3v26c0 1.7-1.3 3-3 3h-20c-1.7 0-3-1.3-3-3V47c0-1.7 1.3-3 3-3z" fill="#10163d" />
+  <rect x="110" y="48" width="16" height="18" rx="3" fill="#1f2f7c" />
+  <rect x="112" y="51" width="12" height="6" rx="2" fill="url(#e)" />
+  <rect x="112" y="58" width="12" height="6" rx="2" fill="url(#e)" transform="scale(1 -1) translate(0 -118)" />
+  <path d="M34 94c16-6 35-6 52 0" stroke="#7bd1ff" stroke-width="3" stroke-linecap="round" opacity=".6" />
 </svg>

--- a/assets/thumbnails/neon-memory.svg
+++ b/assets/thumbnails/neon-memory.svg
@@ -1,44 +1,52 @@
-<svg width="320" height="200" viewBox="0 0 320 200" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="320" height="200" rx="24" fill="url(#paint0_linear)" />
-  <g filter="url(#filter0_d)">
-    <rect x="68" y="44" width="184" height="132" rx="20" fill="url(#paint1_linear)" stroke="rgba(255,255,255,0.15)" stroke-width="2" />
-    <g transform="translate(0,-6)">
-      <rect x="92" y="78" width="64" height="84" rx="14" fill="url(#paintCard1)" stroke="rgba(123,91,255,0.45)" stroke-width="2" />
-      <rect x="140" y="60" width="64" height="84" rx="14" fill="url(#paintCard2)" stroke="rgba(86,220,255,0.5)" stroke-width="2" />
-      <rect x="188" y="90" width="64" height="84" rx="14" fill="url(#paintCard3)" stroke="rgba(255,214,102,0.6)" stroke-width="2" />
-      <text x="172" y="112" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="34" fill="#F1F4FF">👾</text>
-      <text x="220" y="142" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="34" fill="#F1F4FF">💾</text>
-      <text x="124" y="150" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="34" fill="#F1F4FF">🔮</text>
-    </g>
-    <path d="M100 66h120" stroke="rgba(86,220,255,0.35)" stroke-width="4" stroke-linecap="round" stroke-dasharray="12 10" />
-    <path d="M116 170c40-22 88-22 128 0" stroke="rgba(123,209,255,0.35)" stroke-width="5" stroke-linecap="round" />
-  </g>
+<svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="paint0_linear" x1="40" y1="12" x2="280" y2="188" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#0B0B2D" />
-      <stop offset="1" stop-color="#1A1F52" />
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#151c55" />
+      <stop offset="1" stop-color="#2d145a" />
     </linearGradient>
-    <linearGradient id="paint1_linear" x1="68" y1="44" x2="252" y2="176" gradientUnits="userSpaceOnUse">
-      <stop stop-color="rgba(18,24,60,0.92)" />
-      <stop offset="1" stop-color="rgba(10,16,44,0.95)" />
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#88dcff" />
+      <stop offset="1" stop-color="#c98cff" />
     </linearGradient>
-    <linearGradient id="paintCard1" x1="92" y1="78" x2="156" y2="162" gradientUnits="userSpaceOnUse">
-      <stop stop-color="rgba(60,28,112,0.85)" />
-      <stop offset="1" stop-color="rgba(30,16,78,0.9)" />
+    <linearGradient id="c" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1a2b73" />
+      <stop offset="1" stop-color="#080e28" />
     </linearGradient>
-    <linearGradient id="paintCard2" x1="140" y1="60" x2="204" y2="144" gradientUnits="userSpaceOnUse">
-      <stop stop-color="rgba(24,82,134,0.85)" />
-      <stop offset="1" stop-color="rgba(14,32,94,0.9)" />
+    <linearGradient id="d" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7bffdf" />
+      <stop offset="1" stop-color="#5f9fff" />
     </linearGradient>
-    <linearGradient id="paintCard3" x1="188" y1="90" x2="252" y2="174" gradientUnits="userSpaceOnUse">
-      <stop stop-color="rgba(116,76,34,0.85)" />
-      <stop offset="1" stop-color="rgba(74,42,10,0.88)" />
+    <linearGradient id="e" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffefb5" />
+      <stop offset="1" stop-color="#ffa864" />
     </linearGradient>
-    <filter id="filter0_d" x="48" y="28" width="224" height="172" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feOffset dy="10" />
-      <feGaussianBlur stdDeviation="16" result="blur" />
-      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.02  0 0 0 0 0.08  0 0 0 0 0.24  0 0 0 0.42 0" result="shadow" />
-      <feBlend in="SourceGraphic" in2="shadow" mode="normal" />
-    </filter>
+    <linearGradient id="f" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7d8eff" />
+      <stop offset="1" stop-color="#66d2ff" />
+    </linearGradient>
   </defs>
+  <rect width="160" height="120" rx="20" fill="url(#a)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="#080f28" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="url(#c)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="none" stroke="url(#b)" stroke-width="1.4" />
+  <g transform="translate(32 26)">
+    <rect width="96" height="68" rx="14" fill="#0f1639" />
+    <rect x="10" y="12" width="28" height="40" rx="8" fill="#101641" />
+    <rect x="12" y="14" width="24" height="36" rx="7" fill="#1a255f" />
+    <path d="M20 24l8 8-8 8-8-8z" fill="url(#d)" />
+    <rect x="40" y="8" width="32" height="52" rx="10" fill="#101641" transform="rotate(-12 56 34)" />
+    <rect x="42" y="10" width="28" height="48" rx="9" fill="#1d275f" transform="rotate(-12 56 34)" />
+    <path d="M52 22l18 18-18 18" fill="none" stroke="url(#e)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" transform="rotate(-12 61 40)" />
+    <rect x="72" y="14" width="18" height="26" rx="6" fill="#101641" />
+    <rect x="74" y="16" width="14" height="22" rx="5" fill="#1d285f" />
+    <path d="M81 22l5 5-5 5-5-5z" fill="url(#f)" />
+    <g fill="#7bd4ff" opacity=".45">
+      <circle cx="14" cy="10" r="3" />
+      <circle cx="82" cy="10" r="3" />
+      <circle cx="14" cy="56" r="3" />
+      <circle cx="82" cy="56" r="3" />
+    </g>
+  </g>
+  <path d="M34 94c24-10 68-10 92 0" stroke="#7bd4ff" stroke-width="3" stroke-linecap="round" opacity=".55" />
+  <path d="M38 100c20-8 64-8 84 0" stroke="#ffb465" stroke-width="2" stroke-linecap="round" opacity=".5" />
 </svg>

--- a/assets/thumbnails/online-hustle.svg
+++ b/assets/thumbnails/online-hustle.svg
@@ -1,47 +1,62 @@
-<svg width="320" height="200" viewBox="0 0 320 200" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="320" height="200" rx="24" fill="url(#paint0_linear)"/>
-  <g filter="url(#filter0_d)">
-    <rect x="60" y="48" width="200" height="120" rx="16" fill="url(#paint1_linear)" stroke="rgba(255,255,255,0.18)" stroke-width="2" />
-    <path d="M76 152h168" stroke="rgba(123,209,255,0.6)" stroke-width="3" stroke-linecap="round" stroke-dasharray="6 8" />
-    <rect x="90" y="74" width="80" height="48" rx="10" fill="rgba(10,16,48,0.85)" stroke="rgba(123,91,255,0.55)" stroke-width="2" />
-    <path d="M102 102c8-14 30-14 38 0" stroke="rgba(123,209,255,0.85)" stroke-width="3" stroke-linecap="round" />
-    <circle cx="112" cy="94" r="6" fill="rgba(123,209,255,0.85)" />
-    <circle cx="132" cy="94" r="6" fill="rgba(123,91,255,0.85)" />
-    <rect x="186" y="74" width="64" height="54" rx="12" fill="rgba(123,91,255,0.18)" stroke="rgba(123,91,255,0.45)" stroke-width="2" />
-    <path d="M202 124h32" stroke="rgba(255,255,255,0.55)" stroke-width="3" stroke-linecap="round" />
-    <path d="M198 94h40" stroke="rgba(255,255,255,0.35)" stroke-width="4" stroke-linecap="round" stroke-dasharray="12 10" />
-    <g>
-      <circle cx="112" cy="154" r="16" fill="rgba(255,214,102,0.9)" stroke="rgba(255,240,180,0.8)" stroke-width="3" />
-      <text x="112" y="159" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="12" fill="#23133A">XP</text>
+<svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#161d57" />
+      <stop offset="1" stop-color="#2f165d" />
+    </linearGradient>
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#88dcff" />
+      <stop offset="1" stop-color="#c98cff" />
+    </linearGradient>
+    <linearGradient id="c" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1a2b73" />
+      <stop offset="1" stop-color="#080e27" />
+    </linearGradient>
+    <linearGradient id="d" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7bffdf" />
+      <stop offset="1" stop-color="#5f9fff" />
+    </linearGradient>
+    <linearGradient id="e" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffefb5" />
+      <stop offset="1" stop-color="#ffa864" />
+    </linearGradient>
+    <linearGradient id="f" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7d8eff" />
+      <stop offset="1" stop-color="#66d2ff" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="120" rx="20" fill="url(#a)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="#080f28" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="url(#c)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="none" stroke="url(#b)" stroke-width="1.4" />
+  <g transform="translate(32 22)">
+    <rect width="96" height="52" rx="12" fill="#10163d" />
+    <rect x="6" y="6" width="84" height="36" rx="10" fill="#19265f" />
+    <rect x="12" y="12" width="56" height="24" rx="8" fill="#0f1331" />
+    <rect x="14" y="14" width="52" height="20" rx="7" fill="#1a265f" />
+    <path d="M18 24h44" stroke="#25338a" stroke-width="2" stroke-linecap="round" opacity=".55" />
+    <g transform="translate(70 10)">
+      <rect width="18" height="22" rx="6" fill="#0d132f" />
+      <rect x="3" y="3" width="12" height="16" rx="4" fill="url(#d)" />
+      <path d="M12 4l-4 8 4 8" stroke="#fff" stroke-width="2" stroke-linecap="round" opacity=".55" />
     </g>
-    <g>
-      <circle cx="152" cy="154" r="12" fill="rgba(123,209,255,0.9)" stroke="rgba(180,236,255,0.8)" stroke-width="3" />
-      <text x="152" y="159" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="10" fill="#05102A">$</text>
-    </g>
-    <g>
-      <circle cx="188" cy="154" r="14" fill="rgba(164,120,255,0.9)" stroke="rgba(210,188,255,0.8)" stroke-width="3" />
-      <text x="188" y="159" text-anchor="middle" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="600" font-size="10" fill="#0C0C24">+1</text>
+    <g transform="translate(18 40)" fill="#7bd4ff" opacity=".65">
+      <circle cx="0" cy="0" r="3" />
+      <circle cx="12" cy="0" r="3" />
+      <circle cx="24" cy="0" r="3" />
+      <circle cx="36" cy="0" r="3" />
     </g>
   </g>
-  <defs>
-    <linearGradient id="paint0_linear" x1="32" y1="12" x2="296" y2="188" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#120D3B" />
-      <stop offset="1" stop-color="#1B2B68" />
-    </linearGradient>
-    <linearGradient id="paint1_linear" x1="60" y1="48" x2="260" y2="168" gradientUnits="userSpaceOnUse">
-      <stop stop-color="rgba(28,36,92,0.95)" />
-      <stop offset="1" stop-color="rgba(14,18,52,0.95)" />
-    </linearGradient>
-    <filter id="filter0_d" x="40" y="32" width="240" height="160" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feOffset dy="10" />
-      <feGaussianBlur stdDeviation="18" result="blur" />
-      <feColorMatrix
-        in="blur"
-        type="matrix"
-        values="0 0 0 0 0.02  0 0 0 0 0.05  0 0 0 0 0.18  0 0 0 0.45 0"
-        result="shadow"
-      />
-      <feBlend in="SourceGraphic" in2="shadow" mode="normal" />
-    </filter>
-  </defs>
+  <g transform="translate(36 74)">
+    <rect width="88" height="26" rx="12" fill="#0d122f" />
+    <rect x="4" y="6" width="80" height="12" rx="6" fill="#1b265d" />
+    <rect x="22" y="10" width="44" height="6" rx="3" fill="url(#f)" />
+  </g>
+  <g transform="translate(108 62)">
+    <circle cx="16" cy="16" r="16" fill="#121741" />
+    <circle cx="16" cy="16" r="12" fill="url(#e)" />
+    <path d="M16 8l4 4h-3v4h3l-4 4" stroke="#7c3e00" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
+  <path d="M36 96c28-12 68-12 96 0" stroke="#7bd4ff" stroke-width="3" stroke-linecap="round" opacity=".5" />
+  <path d="M36 100c24-10 68-10 96 0" stroke="#ffb465" stroke-width="2" stroke-linecap="round" opacity=".5" />
 </svg>

--- a/assets/thumbnails/petak.svg
+++ b/assets/thumbnails/petak.svg
@@ -1,0 +1,69 @@
+<svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#141b51" />
+      <stop offset="1" stop-color="#2c145b" />
+    </linearGradient>
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#88dcff" />
+      <stop offset="1" stop-color="#c98cff" />
+    </linearGradient>
+    <linearGradient id="c" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1a2b73" />
+      <stop offset="1" stop-color="#080e28" />
+    </linearGradient>
+    <linearGradient id="d" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7bffdf" />
+      <stop offset="1" stop-color="#5f9fff" />
+    </linearGradient>
+    <linearGradient id="e" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffefb5" />
+      <stop offset="1" stop-color="#ffa864" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="120" rx="20" fill="url(#a)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="#080f28" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="url(#c)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="none" stroke="url(#b)" stroke-width="1.4" />
+  <g transform="translate(32 26)">
+    <rect width="96" height="68" rx="14" fill="#0f163a" />
+    <rect x="8" y="12" width="80" height="44" rx="10" fill="#19265f" />
+    <g transform="translate(12 16)" stroke="#24348c" stroke-width="2" opacity=".6">
+      <path d="M0 0h68" />
+      <path d="M0 18h68" />
+      <path d="M0 36h68" />
+      <path d="M0 0v54" />
+      <path d="M17 0v54" />
+      <path d="M34 0v54" />
+      <path d="M51 0v54" />
+      <path d="M68 0v54" />
+    </g>
+    <g transform="translate(12 16)">
+      <rect width="17" height="18" rx="5" fill="#121742" />
+      <rect x="17" width="17" height="18" rx="5" fill="#121742" />
+      <rect x="34" width="17" height="18" rx="5" fill="#121742" />
+      <rect x="51" width="17" height="18" rx="5" fill="#121742" />
+      <rect x="0" y="18" width="17" height="18" rx="5" fill="#121742" />
+      <rect x="17" y="18" width="17" height="18" rx="5" fill="#121742" />
+      <rect x="34" y="18" width="17" height="18" rx="5" fill="#121742" />
+      <rect x="51" y="18" width="17" height="18" rx="5" fill="#121742" />
+      <rect x="0" y="36" width="17" height="18" rx="5" fill="#121742" />
+      <rect x="17" y="36" width="17" height="18" rx="5" fill="#121742" />
+      <rect x="34" y="36" width="17" height="18" rx="5" fill="#121742" />
+      <rect x="51" y="36" width="17" height="18" rx="5" fill="#121742" />
+      <rect x="17" width="17" height="18" rx="5" fill="url(#d)" opacity=".9" />
+      <rect x="34" y="18" width="17" height="18" rx="5" fill="url(#e)" opacity=".9" />
+      <rect x="51" y="36" width="17" height="18" rx="5" fill="#1b285f" opacity=".6" />
+    </g>
+    <g transform="translate(18 20)" fill="#fff" font-family="'Space Grotesk', 'Poppins', sans-serif" font-weight="700" font-size="10">
+      <text x="8.5" y="12">P</text>
+      <text x="25.5" y="12">E</text>
+      <text x="42.5" y="30">T</text>
+      <text x="59.5" y="48">A</text>
+      <text x="76.5" y="12" fill="#7bd4ff">K</text>
+    </g>
+    <path d="M12 54h68" stroke="#7bd4ff" stroke-width="2.5" stroke-linecap="round" opacity=".5" />
+  </g>
+  <path d="M34 96c24-10 68-10 92 0" stroke="#7bd4ff" stroke-width="3" stroke-linecap="round" opacity=".55" />
+  <path d="M34 100c28-12 92-12 120 0" stroke="#ffb465" stroke-width="2" stroke-linecap="round" opacity=".45" />
+</svg>

--- a/assets/thumbnails/simple-mover.svg
+++ b/assets/thumbnails/simple-mover.svg
@@ -1,22 +1,54 @@
 <svg width="160" height="120" viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="gradMover" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#38bdf8"/>
-      <stop offset="100%" stop-color="#6366f1"/>
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#141b51" />
+      <stop offset="1" stop-color="#2c145b" />
     </linearGradient>
-    <linearGradient id="sparkMover" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#e0f2fe" stop-opacity="0.2"/>
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#86ddff" />
+      <stop offset="1" stop-color="#c88cff" />
+    </linearGradient>
+    <linearGradient id="c" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1a2b73" />
+      <stop offset="1" stop-color="#080e27" />
+    </linearGradient>
+    <linearGradient id="d" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7bffdf" />
+      <stop offset="1" stop-color="#5f9fff" />
+    </linearGradient>
+    <linearGradient id="e" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffefb5" />
+      <stop offset="1" stop-color="#ffa764" />
     </linearGradient>
   </defs>
-  <rect x="0" y="0" width="160" height="120" rx="16" fill="url(#gradMover)"/>
-  <g fill="none" stroke="url(#sparkMover)" stroke-width="6" stroke-linecap="round">
-    <path d="M30 86 L70 46"/>
-    <path d="M70 46 L94 70"/>
-    <path d="M94 70 L130 34"/>
+  <rect width="160" height="120" rx="20" fill="url(#a)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="#080f28" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="url(#c)" />
+  <rect x="6" y="6" width="148" height="108" rx="16" fill="none" stroke="url(#b)" stroke-width="1.4" />
+  <g transform="translate(30 24)">
+    <rect width="100" height="72" rx="14" fill="#0f163b" />
+    <rect x="8" y="8" width="84" height="56" rx="12" fill="#16225a" />
+    <rect x="26" y="26" width="48" height="20" rx="8" fill="#0d1332" />
+    <rect x="28" y="28" width="44" height="16" rx="6" fill="#1a255f" />
+    <path d="M20 14h60" stroke="#25348b" stroke-width="2" stroke-linecap="round" opacity=".5" />
+    <path d="M20 62h60" stroke="#25348b" stroke-width="2" stroke-linecap="round" opacity=".5" />
+    <path d="M18 24l12 12-12 12" stroke="#7bd4ff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M82 24l-12 12 12 12" stroke="#ffb365" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="50" cy="36" r="14" fill="#10173f" />
+    <circle cx="50" cy="36" r="10" fill="#0f112d" />
+    <circle cx="50" cy="36" r="7" fill="url(#d)" />
+    <circle cx="50" cy="36" r="3" fill="#fff" opacity=".6" />
+    <g fill="#ffb76a" opacity=".65">
+      <circle cx="22" cy="16" r="3" />
+      <circle cx="78" cy="16" r="3" />
+      <circle cx="22" cy="56" r="3" />
+      <circle cx="78" cy="56" r="3" />
+    </g>
   </g>
-  <circle cx="70" cy="46" r="12" fill="#f8fafc" opacity="0.85"/>
-  <circle cx="94" cy="70" r="10" fill="#e0f2fe" opacity="0.9"/>
-  <circle cx="130" cy="34" r="8" fill="#c4b5fd" opacity="0.9"/>
-  <text x="32" y="36" font-family="'Poppins', sans-serif" font-weight="600" font-size="14" fill="#e0f2fe">DASH!</text>
+  <g transform="translate(54 84)">
+    <rect width="52" height="18" rx="9" fill="#0d1231" />
+    <rect x="4" y="4" width="44" height="10" rx="5" fill="#1b265d" />
+    <rect x="18" y="6" width="16" height="6" rx="3" fill="url(#e)" />
+  </g>
+  <path d="M34 96c24-10 68-10 92 0" stroke="#7bd4ff" stroke-width="3" stroke-linecap="round" opacity=".5" />
 </svg>

--- a/index.html
+++ b/index.html
@@ -417,6 +417,7 @@
               <span class="ticker-item">Neon Memory Challenge · Ultra-fast rounds for puzzle lovers</span>
               <span class="ticker-item">Online Hustle Simulator · Build your pixel empire, no sleep required</span>
               <span class="ticker-item">Brick Breaker Combo Mode · Chase perfect clears with new pacing tips</span>
+              <span class="ticker-item">Petak Word Rush · Crush the daily puzzle with neon keyboard clues</span>
               <span class="ticker-item">Neon Memory Challenge · Ultra-fast rounds for puzzle lovers</span>
               <span class="ticker-item">Online Hustle Simulator · Build your pixel empire, no sleep required</span>
               <span class="ticker-item">Brick Breaker Combo Mode · Chase perfect clears with new pacing tips</span>
@@ -545,6 +546,18 @@
               <span>Memory Rush</span>
               <h2>Neon Memory</h2>
               <p>Flip neon tiles, lock in the pairs, and clear the board before the tempo maxes out.</p>
+            </div>
+          </a>
+
+          <a class="game-card card-surface" href="./petak/" role="listitem" data-status="new">
+            <span class="card-chip">New</span>
+            <div class="card-thumb" aria-hidden="true">
+              <img src="./assets/thumbnails/petak.svg" alt="" loading="lazy" />
+            </div>
+            <div class="card-meta">
+              <span>Word Puzzle</span>
+              <h2>Petak</h2>
+              <p>Crack the five-letter code in Serbian, mixing diacritics and clues before attempts run out.</p>
             </div>
           </a>
         </div>


### PR DESCRIPTION
## Summary
- refresh every arcade thumbnail with layered neon artwork that matches the cabinet palette
- add the Petak word puzzle to the homepage grid, ticker highlight, and README catalogue

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d94d5ac954832c8359f30698adf205