### PR TITLE
Refactor Flappy Bird layout for shared arcade shell

### DIFF
--- a/flappy-bird/index.html
+++ b/flappy-bird/index.html
@@ -22,43 +22,52 @@
       </header>
 
       <main class="arcade-main">
-        <div class="layout">
-          <section class="info-panel">
-            <h2>Flappy Bird - Neon Skies</h2>
-            <p>
-              Glide through a corridor of neon pipes and keep the bird afloat. Tap or
-              press space to flap, dodge obstacles, and chase your high score in this
-              retro-inspired remake.
-            </p>
-            <ul>
-              <li><strong>Flap:</strong> Spacebar, click, or tap</li>
-              <li><strong>Stay alive:</strong> Avoid pipes and the ground</li>
-              <li><strong>Restart:</strong> Hit the play again button or press R</li>
-            </ul>
-            <p class="tip">Pro tip: rhythmic taps keep you steady through tight gaps!</p>
-          </section>
-          <section class="game-panel">
+        <div class="arcade-game">
+          <section class="arcade-game__stage">
             <div class="game-container">
-              <div class="hud">
-                <div class="score" id="scoreDisplay">0</div>
-              </div>
-              <canvas
-                id="gameCanvas"
-                width="480"
-                height="640"
-                role="img"
-                aria-label="Flappy Bird arcade canvas"
-              ></canvas>
-              <div class="game-over hidden" id="gameOver">
-                <h2 class="game-over__title">Game Over</h2>
-                <p class="game-over__score">
-                  Final Score: <span id="finalScore">0</span>
-                </p>
-                <button class="retry-button" id="retryButton">Play Again</button>
-                <p class="game-over__hint">Press Space, Tap, or R to restart</p>
+              <div class="arcade-game__frame">
+                <canvas
+                  id="gameCanvas"
+                  width="480"
+                  height="640"
+                  role="img"
+                  aria-label="Flappy Bird arcade canvas"
+                ></canvas>
+                <div class="hud">
+                  <div class="score" id="scoreDisplay">0</div>
+                </div>
+                <div class="game-over hidden" id="gameOver">
+                  <h2 class="game-over__title">Game Over</h2>
+                  <p class="game-over__score">
+                    Final Score: <span id="finalScore">0</span>
+                  </p>
+                  <button class="retry-button" id="retryButton">Play Again</button>
+                  <p class="game-over__hint">Press Space, Tap, or R to restart</p>
+                </div>
               </div>
             </div>
           </section>
+          <aside class="arcade-game__sidebar">
+            <article class="arcade-panel">
+              <h2>Flappy Bird - Neon Skies</h2>
+              <p>
+                Glide through a corridor of neon pipes and keep the bird afloat. Tap or
+                press space to flap, dodge obstacles, and chase your high score in this
+                retro-inspired remake.
+              </p>
+            </article>
+            <article class="arcade-panel">
+              <h3>How to Play</h3>
+              <ul>
+                <li><strong>Flap:</strong> Spacebar, click, or tap</li>
+                <li><strong>Stay alive:</strong> Avoid pipes and the ground</li>
+                <li><strong>Restart:</strong> Hit the play again button or press R</li>
+              </ul>
+            </article>
+            <article class="arcade-panel arcade-panel--highlight">
+              <p class="tip">Pro tip: rhythmic taps keep you steady through tight gaps!</p>
+            </article>
+          </aside>
         </div>
       </main>
 

--- a/flappy-bird/style.css
+++ b/flappy-bird/style.css
@@ -25,75 +25,54 @@ body {
   align-items: stretch;
 }
 
-.layout {
+.arcade-game {
+  --arcade-stage-width: 520px;
   display: grid;
   grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
-  gap: 2.75rem;
-  width: min(1100px, 100%);
-  align-items: center;
+  gap: clamp(2rem, 4vw, 2.75rem);
+  align-items: start;
 }
 
-.info-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.info-panel h2 {
-  margin: 0;
-  font-size: clamp(2.25rem, 4vw, 3rem);
-  line-height: 1.1;
-}
-
-p {
-  margin: 0;
-  color: #c9d9f7;
-  font-size: 1.05rem;
-}
-
-ul {
-  margin: 0;
-  padding-left: 1.2rem;
-  color: #91a7d6;
-  display: grid;
-  gap: 0.35rem;
-  font-size: 1.05rem;
-}
-
-.tip {
-  color: #82ffe3;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.85rem;
-}
-
-.game-panel {
-  background: linear-gradient(160deg, rgba(13, 26, 48, 0.95), rgba(7, 13, 24, 0.95));
-  padding: 1.5rem;
+.arcade-game__stage {
+  padding: clamp(1.25rem, 2.4vw, 1.6rem);
   border-radius: 1.5rem;
+  background: linear-gradient(160deg, rgba(13, 26, 48, 0.95), rgba(7, 13, 24, 0.95));
+  border: 1px solid rgba(130, 255, 227, 0.18);
   box-shadow: 0 30px 60px rgba(0, 0, 0, 0.45);
+  display: flex;
+  justify-content: center;
 }
 
 .game-container {
-  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
-canvas {
-  width: min(100%, 520px);
-  height: auto;
-  display: block;
+.arcade-game__frame {
+  position: relative;
+  width: 100%;
+  max-width: var(--arcade-stage-width);
+  margin: 0 auto;
   border-radius: 1.15rem;
+  border: 4px solid rgba(130, 255, 227, 0.4);
   background: radial-gradient(circle at 50% 25%, rgba(45, 74, 140, 0.6), transparent 55%),
     linear-gradient(180deg, #0c1230, #1b2d69 40%, #0d1a3c 70%, #090f22 100%);
-  border: 4px solid rgba(130, 255, 227, 0.4);
   box-shadow: inset 0 0 25px rgba(9, 250, 211, 0.25);
+  overflow: hidden;
+}
+
+.arcade-game__frame canvas {
+  display: block;
+  width: min(100%, var(--arcade-stage-width));
+  height: auto;
+  background: transparent;
   touch-action: none;
 }
 
 .hud {
   position: absolute;
-  top: 1.25rem;
+  top: clamp(1rem, 2.5vw, 1.25rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -103,7 +82,7 @@ canvas {
 
 .score {
   min-width: 4.5rem;
-  padding: 0.4rem 1.25rem;
+  padding: 0.45rem 1.35rem;
   border-radius: 999px;
   background: rgba(8, 14, 25, 0.65);
   border: 1px solid rgba(130, 255, 227, 0.45);
@@ -123,7 +102,7 @@ canvas {
   justify-content: center;
   text-align: center;
   gap: 1.1rem;
-  padding: 2.5rem 2rem;
+  padding: clamp(2rem, 4vw, 2.5rem) clamp(1.5rem, 3vw, 2rem);
   border-radius: 1.15rem;
   background: rgba(4, 8, 18, 0.86);
   backdrop-filter: blur(6px);
@@ -157,7 +136,7 @@ canvas {
   appearance: none;
   border: none;
   border-radius: 999px;
-  padding: 0.9rem 2.5rem;
+  padding: 0.95rem 2.6rem;
   font-size: 1.05rem;
   font-weight: 600;
   cursor: pointer;
@@ -177,27 +156,139 @@ canvas {
   outline-offset: 4px;
 }
 
-@media (max-width: 960px) {
-  .layout {
-    grid-template-columns: 1fr;
-    text-align: center;
-  }
+.arcade-game__sidebar {
+  display: grid;
+  gap: clamp(1.25rem, 2.8vw, 1.75rem);
+}
 
-  .info-panel {
-    align-items: center;
-  }
+.arcade-panel {
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1.35rem, 3vw, 1.75rem);
+  border-radius: 1.25rem;
+  background: linear-gradient(150deg, rgba(15, 28, 52, 0.78), rgba(10, 18, 36, 0.9));
+  border: 1px solid rgba(130, 255, 227, 0.12);
+  box-shadow: 0 22px 45px rgba(4, 12, 32, 0.45);
+}
 
+.arcade-panel--highlight {
+  background: linear-gradient(140deg, rgba(130, 255, 227, 0.18), rgba(10, 18, 36, 0.92));
+  border-color: rgba(130, 255, 227, 0.35);
+}
+
+.arcade-panel h2 {
+  margin: 0;
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  line-height: 1.1;
+}
+
+.arcade-panel h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #82ffe3;
+}
+
+p {
+  margin: 0;
+  color: #c9d9f7;
+  font-size: 1.05rem;
+}
+
+.arcade-panel ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #91a7d6;
+  display: grid;
+  gap: 0.45rem;
+  font-size: 1.05rem;
+}
+
+.tip {
+  color: #82ffe3;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 1024px) {
   body {
-    padding: 1.75rem 1.25rem;
+    padding: 1.85rem 1.35rem;
+  }
+
+  .arcade-game {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2rem;
+  }
+
+  .arcade-game__stage {
+    justify-self: center;
+  }
+
+  .arcade-game__sidebar {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 720px) {
+  body {
+    padding: 1.75rem 1.2rem;
+  }
+
+  .arcade-game {
+    --arcade-stage-width: 460px;
+    gap: 1.75rem;
+  }
+
+  .arcade-panel {
+    padding: 1.45rem;
+  }
+
+  .arcade-panel h2 {
+    font-size: clamp(2rem, 6vw, 2.6rem);
+  }
+
+  .arcade-panel ul {
+    padding-left: 1rem;
+  }
+}
+
+@media (max-width: 560px) {
   body {
     padding: 1.5rem 1rem;
   }
 
-  canvas {
-    border-width: 3px;
+  .arcade-game {
+    --arcade-stage-width: 420px;
+  }
+
+  .hud {
+    top: 0.9rem;
+  }
+
+  .score {
+    padding: 0.5rem 1.45rem;
+    font-size: 1.25rem;
+  }
+
+  .retry-button {
+    padding: 1rem 2.75rem;
+    font-size: 1.1rem;
+  }
+
+  .arcade-panel {
+    padding: 1.35rem;
+    gap: 0.9rem;
+  }
+
+  .arcade-panel h3 {
+    letter-spacing: 0.12em;
+  }
+
+  .tip {
+    font-size: 0.9rem;
+    letter-spacing: 0.12em;
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the Flappy Bird page around the shared `.arcade-game` layout with a framed stage and sidebar panels
- update the game canvas container and overlays so the frame controls sizing via `--arcade-stage-width`
- restyle the sidebar information as `.arcade-panel` cards and tune breakpoints for stacked, touch-friendly spacing

## Testing
- Manual smoke test in browser

------
https://chatgpt.com/codex/tasks/task_e_68d94d43b554832cb46a39173486d880