### PR TITLE
Refactor Simple Mover layout into arcade frame and sidebar

### DIFF
--- a/simple_mover/index.html
+++ b/simple_mover/index.html
@@ -22,33 +22,33 @@
     </header>
 
     <main class="arcade-main">
-      <div class="layout">
-        <section class="game-panel">
-          <div class="game-container">
-            <canvas
-              id="game"
-              width="1200"
-              height="720"
-              aria-label="Simple mover game"
-              role="img"
-            ></canvas>
-          </div>
+      <div class="arcade-game">
+        <section class="arcade-game__frame">
+          <canvas
+            id="game"
+            width="1200"
+            height="720"
+            aria-label="Simple mover game"
+            role="img"
+          ></canvas>
         </section>
-        <section class="info-panel">
-          <h2>Quick controls</h2>
-          <p>
-            Use the arrow keys or WASD to move the blue square. Collect stars to gain points and avoid the red walls!
-          </p>
-          <ul>
-            <li><strong>Arrow Keys / WASD</strong>: Move</li>
-            <li><strong>Space</strong>: Dash (short burst of speed)</li>
-            <li><strong>R</strong>: Restart instantly after a crash</li>
-          </ul>
-          <p>
-            Colliding with a wall pauses the action briefly before you respawn in a now-larger arena—press
-            <strong>R</strong> if you want to restart immediately.
-          </p>
-        </section>
+        <aside class="arcade-game__sidebar">
+          <article class="arcade-panel card-surface">
+            <h2>Quick controls</h2>
+            <p>
+              Use the arrow keys or WASD to move the blue square. Collect stars to gain points and avoid the red walls!
+            </p>
+            <ul>
+              <li><strong>Arrow Keys / WASD</strong>: Move</li>
+              <li><strong>Space</strong>: Dash (short burst of speed)</li>
+              <li><strong>R</strong>: Restart instantly after a crash</li>
+            </ul>
+            <p>
+              Colliding with a wall pauses the action briefly before you respawn in a now-larger arena—press
+              <strong>R</strong> if you want to restart immediately.
+            </p>
+          </article>
+        </aside>
       </div>
     </main>
 

--- a/simple_mover/styles.css
+++ b/simple_mover/styles.css
@@ -3,6 +3,7 @@
   font-family: 'Poppins', 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background-color: #080820;
   color: #f0f6ff;
+  --arcade-stage-width: min(100%, 75rem);
 }
 
 body {
@@ -19,71 +20,86 @@ body {
   align-items: stretch;
 }
 
-.layout {
+.arcade-game {
   display: grid;
   grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
-  gap: 2.5rem;
-  padding: 2.5rem;
-  max-width: 1400px;
-  width: 100%;
-  box-sizing: border-box;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  align-items: start;
 }
 
-.game-panel {
-  background: linear-gradient(145deg, #162a3b, #0d1722);
-  padding: 1.5rem;
+.arcade-game__frame {
+  max-width: var(--arcade-stage-width);
+  width: 100%;
+  margin: 0 auto;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
   border-radius: 1.25rem;
+  background: linear-gradient(145deg, #162a3b, #0d1722);
   box-shadow: 0 2rem 3.5rem rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
 }
 
 canvas {
+  display: block;
   width: 100%;
+  max-width: var(--arcade-stage-width);
   height: auto;
   border-radius: 0.85rem;
   background: #05090f;
-  display: block;
 }
 
-.game-container {
-  position: relative;
-}
-
-.info-panel {
+.arcade-game__sidebar {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  gap: 1rem;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
 }
 
-.info-panel h2 {
+.arcade-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  background: rgba(12, 14, 40, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.25rem;
+  box-shadow: 0 16px 34px rgba(0, 0, 0, 0.35);
+}
+
+.arcade-panel h2 {
   margin: 0;
-  font-size: 2.5rem;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
   line-height: 1.2;
   font-family: 'Space Grotesk', 'Poppins', sans-serif;
 }
 
-p {
+.arcade-panel p {
   margin: 0;
   color: #ced9ec;
 }
 
-ul {
+.arcade-panel ul {
   margin: 0;
   padding-left: 1.2rem;
   color: #9fb6d4;
 }
 
-@media (max-width: 768px) {
-  .layout {
+@media (max-width: 960px) {
+  .arcade-game {
     grid-template-columns: 1fr;
-    text-align: center;
+    justify-items: center;
   }
 
-  .info-panel {
+  .arcade-game__sidebar {
+    width: min(100%, var(--arcade-stage-width));
     align-items: center;
   }
 
-  .game-panel {
-    order: -1;
+  .arcade-panel {
+    width: min(100%, 32rem);
+    text-align: center;
+  }
+
+  .arcade-panel ul {
+    text-align: left;
   }
 }


### PR DESCRIPTION
## Summary
- restructure the Simple Mover page so the canvas lives inside an `.arcade-game__frame` and the guidance sits within a sidebar card
- replace the bespoke layout grid with styles driven by `--arcade-stage-width`, including responsive centering of the sidebar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d94d4ea06c832cbf7b7f1fceec7863