### PR TITLE
Refresh homepage for unified arcade UI

### DIFF
--- a/assets/js/arcade.js
+++ b/assets/js/arcade.js
@@ -4,7 +4,8 @@
     el.textContent = year;
   });
 
-  const cards = Array.from(document.querySelectorAll('.game-grid .game-card'));
+  const allCards = Array.from(document.querySelectorAll('.game-grid .game-card'));
+  const playableCards = allCards.filter((card) => card.getAttribute('aria-disabled') !== 'true');
   const totalGamesEl = document.querySelector('[data-total-games]');
   const newGamesEl = document.querySelector('[data-new-games]');
   const statusEl = document.querySelector('[data-status-rotator]');
@@ -12,11 +13,11 @@
   const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   if (totalGamesEl) {
-    totalGamesEl.textContent = cards.length.toString();
+    totalGamesEl.textContent = playableCards.length.toString();
   }
 
   if (newGamesEl) {
-    const newGames = cards.filter((card) => card.dataset.status === 'new').length;
+    const newGames = playableCards.filter((card) => card.dataset.status === 'new').length;
     newGamesEl.textContent = newGames.toString();
   }
 
@@ -24,6 +25,7 @@
     'Queueing power-ups... almost there!',
     'Cycling neon lights for optimal vibes.',
     'Listening for high-score whispers in the cabinet.',
+    'Syncing the uniform cabinet shell for your run.',
     'Spinning the arcade wheel for your next run.',
   ];
 
@@ -35,13 +37,13 @@
     }, 7000);
   }
 
-  if (shuffleButton && cards.length) {
+  if (shuffleButton && playableCards.length) {
     let highlightTimeout;
 
     shuffleButton.addEventListener('click', () => {
-      const choice = cards[Math.floor(Math.random() * cards.length)];
+      const choice = playableCards[Math.floor(Math.random() * playableCards.length)];
 
-      cards.forEach((card) => card.classList.remove('is-highlighted'));
+      allCards.forEach((card) => card.classList.remove('is-highlighted'));
       choice.classList.add('is-highlighted');
 
       const gameName = choice.querySelector('h2')?.textContent?.trim() ?? 'your next game';

--- a/assets/thumbnails/photon-drift.svg
+++ b/assets/thumbnails/photon-drift.svg
@@ -1,0 +1,48 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="240" height="240" rx="36" fill="url(#paint0_radial)"/>
+  <g filter="url(#filter0_f)">
+    <circle cx="180" cy="76" r="46" fill="url(#paint1_radial)"/>
+  </g>
+  <g filter="url(#filter1_f)">
+    <circle cx="68" cy="170" r="56" fill="url(#paint2_radial)"/>
+  </g>
+  <path d="M54 118c22-32 60-52 99-51 28 0.6 53 10.7 73 27.3l-19 18.2c-15.5-12.8-33.9-19.6-54-20.1-28.5-0.7-55.6 12.4-73.7 35.6l-25.3-10.9Z" fill="url(#paint3_linear)"/>
+  <path d="M80.4 158.4c16.3-23.2 45.4-37.6 74.8-36.3 18.7 0.8 35.5 7.4 49 18.5l-17.6 16.5c-9.4-7.5-20.7-11.9-33-12.4-20.4-0.8-39.6 9.4-52.5 26.6l-20.7-12.9Z" stroke="#F5ECFF" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.6"/>
+  <path d="M93 184.5c9.1-14.1 26-22.9 43.4-22.2 12 0.5 22.9 5 31.8 12.8L153 193c-6-4.8-13.2-7.6-20.8-7.9-11.4-0.5-22.1 5.2-29.4 14.7L93 184.5Z" fill="#F7E8FF" opacity="0.85"/>
+  <circle cx="96" cy="80" r="26" fill="url(#paint4_radial)" stroke="#F8F9FF" stroke-width="4"/>
+  <circle cx="143" cy="124" r="14" fill="#F8F9FF" opacity="0.9"/>
+  <path d="M130 125c-7.4-7-8.3-18.4-2-26.3 6.3-8 17.6-10 26.3-4.6" stroke="#F8F9FF" stroke-width="6" stroke-linecap="round" opacity="0.45"/>
+  <defs>
+    <filter id="filter0_f" x="104" y="0" width="152" height="152" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feGaussianBlur stdDeviation="12" result="effect1_foregroundBlur"/>
+    </filter>
+    <filter id="filter1_f" x="0" y="102" width="136" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feGaussianBlur stdDeviation="14" result="effect1_foregroundBlur"/>
+    </filter>
+    <radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(48 38) rotate(42) scale(240 220)">
+      <stop stop-color="#5F4BFF"/>
+      <stop offset="0.45" stop-color="#3E2BA8"/>
+      <stop offset="1" stop-color="#120B3E"/>
+    </radialGradient>
+    <radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(180 76) rotate(90) scale(46)">
+      <stop stop-color="#F4FFBC" stop-opacity="0.9"/>
+      <stop offset="1" stop-color="#F4FFBC" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="paint2_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(68 170) rotate(90) scale(56)">
+      <stop stop-color="#8AE4FF" stop-opacity="0.75"/>
+      <stop offset="1" stop-color="#8AE4FF" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="paint3_linear" x1="66" y1="88" x2="202" y2="148" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFE89A" stop-opacity="0.85"/>
+      <stop offset="1" stop-color="#8AD5FF" stop-opacity="0.3"/>
+    </linearGradient>
+    <radialGradient id="paint4_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(96 80) rotate(90) scale(26)">
+      <stop stop-color="#FFEB9A"/>
+      <stop offset="1" stop-color="#FFEB9A" stop-opacity="0.1"/>
+    </radialGradient>
+  </defs>
+</svg>

--- a/index.html
+++ b/index.html
@@ -21,6 +21,24 @@
         gap: clamp(2rem, 4vw, 3rem);
       }
 
+      .frame-stack {
+        display: flex;
+        flex-direction: column;
+        gap: var(--frame-stack-gap, 1rem);
+      }
+
+      .frame-cluster {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--frame-cluster-gap, 0.75rem);
+      }
+
+      .frame-grid {
+        display: grid;
+        gap: var(--frame-grid-gap, 1rem);
+      }
+
       .hero {
         position: relative;
         display: grid;
@@ -161,10 +179,9 @@
       }
 
       .hero-widget__stats {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 0.75rem;
+        --frame-grid-gap: 0.75rem;
         margin: 0;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
       }
 
       .hero-widget__stats div {
@@ -187,6 +204,24 @@
         margin: 0;
         font-size: 1.5rem;
         font-weight: 600;
+        line-height: 1.1;
+      }
+
+      .hero-widget__stats dd span {
+        display: block;
+      }
+
+      .hero-widget__stats dd small {
+        display: block;
+        font-size: 0.75rem;
+        font-weight: 500;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: rgba(248, 249, 255, 0.6);
+      }
+
+      .stat-accent {
+        color: rgba(123, 209, 255, 0.95);
       }
 
       .hero-widget__status {
@@ -223,9 +258,7 @@
       }
 
       .badge-row {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.75rem;
+        --frame-cluster-gap: 0.75rem;
       }
 
       .hero-badge {
@@ -266,6 +299,12 @@
         color: rgba(200, 245, 255, 0.85);
       }
 
+      .card-chip--upcoming {
+        background: rgba(255, 196, 86, 0.18);
+        border-color: rgba(255, 196, 86, 0.65);
+        color: rgba(255, 231, 175, 0.9);
+      }
+
       .game-card::after {
         content: '';
         position: absolute;
@@ -299,18 +338,109 @@
         opacity: 1;
       }
 
+      .game-card[aria-disabled='true'] {
+        cursor: not-allowed;
+        opacity: 0.85;
+      }
+
+      .game-card[aria-disabled='true'] .card-thumb::after {
+        opacity: 0.45;
+      }
+
+      .game-card[aria-disabled='true'] .card-meta p {
+        color: rgba(248, 249, 255, 0.6);
+      }
+
+      .game-card--upcoming .card-thumb {
+        justify-content: center;
+        padding: 2rem 1.5rem;
+      }
+
+      .game-card--upcoming .card-meta {
+        gap: 0.5rem;
+      }
+
+      .game-card[aria-disabled='true']:hover,
+      .game-card[aria-disabled='true']:focus-visible {
+        transform: none;
+        box-shadow: 0 26px 60px rgba(10, 14, 40, 0.45);
+      }
+
       .card-thumb {
+        --thumb-bg: rgba(255, 255, 255, 0.08);
         overflow: hidden;
         border-radius: 16px;
         position: relative;
-        background: rgba(255, 255, 255, 0.08);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--thumb-bg);
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+      }
+
+      .card-thumb::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.18), transparent 55%),
+          radial-gradient(circle at 80% 20%, rgba(123, 209, 255, 0.16), transparent 60%),
+          radial-gradient(circle at 50% 80%, rgba(255, 135, 219, 0.18), transparent 60%);
+        mix-blend-mode: screen;
+        opacity: 0.65;
+        pointer-events: none;
       }
 
       .card-thumb img {
-        width: 100%;
+        width: 72%;
+        max-width: 180px;
         display: block;
-        object-fit: cover;
-        mix-blend-mode: lighten;
+        object-fit: contain;
+        mix-blend-mode: screen;
+        filter: drop-shadow(0 12px 24px rgba(8, 12, 38, 0.5));
+      }
+
+      .card-thumb[data-thumb='2048'] {
+        --thumb-bg: linear-gradient(135deg, rgba(255, 173, 92, 0.35), rgba(128, 70, 255, 0.4));
+      }
+
+      .card-thumb[data-thumb='flappy'] {
+        --thumb-bg: linear-gradient(135deg, rgba(86, 220, 255, 0.35), rgba(28, 72, 240, 0.45));
+      }
+
+      .card-thumb[data-thumb='connect'] {
+        --thumb-bg: linear-gradient(135deg, rgba(255, 92, 164, 0.35), rgba(120, 64, 255, 0.45));
+      }
+
+      .card-thumb[data-thumb='runner'] {
+        --thumb-bg: linear-gradient(135deg, rgba(255, 126, 92, 0.35), rgba(72, 206, 255, 0.42));
+      }
+
+      .card-thumb[data-thumb='brick'] {
+        --thumb-bg: linear-gradient(135deg, rgba(86, 255, 196, 0.32), rgba(123, 91, 255, 0.45));
+      }
+
+      .card-thumb[data-thumb='mover'] {
+        --thumb-bg: linear-gradient(135deg, rgba(123, 209, 255, 0.35), rgba(12, 19, 67, 0.7));
+      }
+
+      .card-thumb[data-thumb='block'] {
+        --thumb-bg: linear-gradient(135deg, rgba(255, 135, 219, 0.32), rgba(75, 55, 200, 0.55));
+      }
+
+      .card-thumb[data-thumb='hustle'] {
+        --thumb-bg: linear-gradient(135deg, rgba(255, 196, 86, 0.35), rgba(255, 92, 164, 0.4));
+      }
+
+      .card-thumb[data-thumb='memory'] {
+        --thumb-bg: linear-gradient(135deg, rgba(92, 255, 233, 0.32), rgba(92, 123, 255, 0.42));
+      }
+
+      .card-thumb[data-thumb='drift'] {
+        --thumb-bg: linear-gradient(135deg, rgba(255, 235, 138, 0.35), rgba(123, 91, 255, 0.55));
+      }
+
+      .card-thumb[data-thumb='placeholder'] {
+        --thumb-bg: linear-gradient(135deg, rgba(86, 220, 255, 0.25), rgba(123, 91, 255, 0.25));
       }
 
       .card-meta {
@@ -398,155 +528,192 @@
     <div class="arcade-shell">
       <header class="hero">
         <div class="hero-main">
-          <div class="hero-heading">
+          <div class="hero-heading frame-stack">
             <span class="brand-title">Pixel Playground</span>
-            <h1>Pick a challenge and press start</h1>
+            <h1>Uniform cabinet UI, same neon energy</h1>
             <p>
-              Eight bite-sized games built with vanilla JavaScript. Swap between puzzle, reflex,
-              and action challenges without leaving the arcade cabinet theme.
+              Every retro challenge now ships with the shared arcade frame, synced badges, and refreshed thumbnails.
+              Queue up your next run while the new Photon Drift cabinet powers on in the background.
             </p>
           </div>
-          <div class="badge-row">
-            <span class="hero-badge">Keyboard + Touch Friendly</span>
-            <span class="hero-badge">No installs required</span>
-            <span class="hero-badge">Built with vanilla JS</span>
+          <div class="badge-row frame-cluster">
+            <span class="hero-badge">Shared HUD controls</span>
+            <span class="hero-badge">Cabinet theme v2.0</span>
+            <span class="hero-badge">Photon Drift in QA</span>
           </div>
           <div class="hero-ticker card-surface" role="status" aria-live="polite">
-            <span class="ticker-label">Now featuring</span>
+            <span class="ticker-label">Update log</span>
             <div class="ticker-track">
-              <span class="ticker-item">Neon Memory Challenge · Ultra-fast rounds for puzzle lovers</span>
-              <span class="ticker-item">Online Hustle Simulator · Build your pixel empire, no sleep required</span>
-              <span class="ticker-item">Brick Breaker Combo Mode · Chase perfect clears with new pacing tips</span>
-              <span class="ticker-item">Neon Memory Challenge · Ultra-fast rounds for puzzle lovers</span>
-              <span class="ticker-item">Online Hustle Simulator · Build your pixel empire, no sleep required</span>
-              <span class="ticker-item">Brick Breaker Combo Mode · Chase perfect clears with new pacing tips</span>
+              <span class="ticker-item">Uniform cabinet UI is live across the entire Pixel Playground roster.</span>
+              <span class="ticker-item">Photon Drift prototype enters final testing—wishlist the cabinet now.</span>
+              <span class="ticker-item">Shared stat badges mirror every in-game overlay for frictionless swaps.</span>
+              <span class="ticker-item">Uniform cabinet UI is live across the entire Pixel Playground roster.</span>
+              <span class="ticker-item">Photon Drift prototype enters final testing—wishlist the cabinet now.</span>
+              <span class="ticker-item">Shared stat badges mirror every in-game overlay for frictionless swaps.</span>
             </div>
           </div>
         </div>
         <aside class="hero-widget card-surface" aria-label="Arcade shuffle">
           <span class="hero-widget__badge">Arcade Shuffle</span>
-          <p class="hero-widget__text">Not sure what to play? Let the arcade pick a surprise challenge.</p>
+          <p class="hero-widget__text">
+            The unified cabinet layout syncs HUD controls across every title. Tap surprise to jump straight into a tuned build.
+          </p>
           <button class="hero-widget__button" type="button" data-action="shuffle">
             Surprise me
           </button>
-          <dl class="hero-widget__stats">
+          <dl class="hero-widget__stats frame-grid">
             <div>
-              <dt>Total games</dt>
+              <dt>Playable now</dt>
               <dd><span data-total-games>0</span></dd>
             </div>
             <div>
+              <dt>Uniform HUD rollout</dt>
+              <dd><span>100%</span><small>Cabinet parity</small></dd>
+            </div>
+            <div>
+              <dt>Next launch</dt>
+              <dd><span class="stat-accent">Photon Drift</span><small>In QA</small></dd>
+            </div>
+            <div>
               <dt>Fresh drops</dt>
-              <dd><span data-new-games>0</span></dd>
+              <dd><span data-new-games>0</span><small>Marked new</small></dd>
             </div>
           </dl>
           <p class="hero-widget__status" data-status-rotator>
-            Press the surprise button to highlight your next adventure.
+            Press surprise to sample the new cabinet frame in action.
           </p>
         </aside>
       </header>
 
       <main>
         <div class="game-grid" role="list">
-          <a class="game-card card-surface" href="./2048/" role="listitem">
-            <div class="card-thumb" aria-hidden="true">
+          <a class="game-card card-surface frame-stack" href="./2048/" role="listitem">
+            <div class="card-thumb" data-thumb="2048" aria-hidden="true">
               <img src="./assets/thumbnails/2048.svg" alt="" loading="lazy" />
             </div>
             <div class="card-meta">
               <span>Swipe Puzzle</span>
               <h2>2048</h2>
-              <p>Join the numbered tiles together until you hit the legendary 2048 block.</p>
+              <p>Swipe merges through the unified cabinet layout to chase the legendary 2048 tile.</p>
             </div>
           </a>
 
-          <a class="game-card card-surface" href="./flappy-bird/" role="listitem">
-            <div class="card-thumb" aria-hidden="true">
+          <a class="game-card card-surface frame-stack" href="./flappy-bird/" role="listitem">
+            <div class="card-thumb" data-thumb="flappy" aria-hidden="true">
               <img src="./assets/thumbnails/flappy-bird.svg" alt="" loading="lazy" />
             </div>
             <div class="card-meta">
               <span>Arcade Reflex</span>
               <h2>Flappy Bird</h2>
-              <p>Tap or press to keep your bird above the pipes in this endless sky gauntlet.</p>
+              <p>Glide through the gaps with synced HUD prompts and a countdown that mirrors in-game cues.</p>
             </div>
           </a>
 
-          <a class="game-card card-surface" href="./connect-four/" role="listitem">
-            <div class="card-thumb" aria-hidden="true">
+          <a class="game-card card-surface frame-stack" href="./connect-four/" role="listitem">
+            <div class="card-thumb" data-thumb="connect" aria-hidden="true">
               <img src="./assets/thumbnails/connect-four.svg" alt="" loading="lazy" />
             </div>
             <div class="card-meta">
               <span>Tabletop Duel</span>
               <h2>Connect Four</h2>
-              <p>Challenge a friend and stack your discs to outsmart the opponent in a row of four.</p>
+              <p>Challenge a friend under the new cabinet lighting and stack discs until the frame declares your win.</p>
             </div>
           </a>
 
-          <a class="game-card card-surface" href="./endless-runner/" role="listitem">
-            <div class="card-thumb" aria-hidden="true">
+          <a class="game-card card-surface frame-stack" href="./endless-runner/" role="listitem">
+            <div class="card-thumb" data-thumb="runner" aria-hidden="true">
               <img src="./assets/thumbnails/endless-runner.svg" alt="" loading="lazy" />
             </div>
             <div class="card-meta">
               <span>Speed Trial</span>
               <h2>Endless Runner</h2>
-              <p>Leap over hazards and keep momentum in this synthwave-inspired sprint.</p>
+              <p>Sprint across neon lanes while the unified overlay tracks your streak and boosts.</p>
             </div>
           </a>
 
-          <a class="game-card card-surface" href="./brick-breaker-clone/" role="listitem">
-            <div class="card-thumb" aria-hidden="true">
+          <a class="game-card card-surface frame-stack" href="./brick-breaker-clone/" role="listitem">
+            <div class="card-thumb" data-thumb="brick" aria-hidden="true">
               <img src="./assets/thumbnails/brick-breaker.svg" alt="" loading="lazy" />
             </div>
             <div class="card-meta">
               <span>Arcade Classic</span>
               <h2>Neon Brick Breaker</h2>
-              <p>Reflect the energy sphere, shatter neon bricks, and chain combos as levels intensify.</p>
+              <p>Reflect energy orbs and shred walls while combo counters sync with the refreshed frame.</p>
             </div>
           </a>
 
-          <a class="game-card card-surface" href="./simple_mover/" role="listitem">
-            <div class="card-thumb" aria-hidden="true">
+          <a class="game-card card-surface frame-stack" href="./simple_mover/" role="listitem">
+            <div class="card-thumb" data-thumb="mover" aria-hidden="true">
               <img src="./assets/thumbnails/simple-mover.svg" alt="" loading="lazy" />
             </div>
             <div class="card-meta">
               <span>Arcade Trainer</span>
               <h2>Simple Mover</h2>
-              <p>Dash around the neon arena, collect stars, and avoid the reactive walls.</p>
+              <p>Dash across the calibrated arena with touch and keyboard cues tuned to the shared layout.</p>
             </div>
           </a>
 
-          <a class="game-card card-surface" href="./tetris_knockoff/" role="listitem">
-            <div class="card-thumb" aria-hidden="true">
+          <a class="game-card card-surface frame-stack" href="./tetris_knockoff/" role="listitem">
+            <div class="card-thumb" data-thumb="block" aria-hidden="true">
               <img src="./assets/thumbnails/block-drop.svg" alt="" loading="lazy" />
             </div>
             <div class="card-meta">
               <span>Falling Blocks</span>
               <h2>Block Drop</h2>
-              <p>Stack tetrominoes with precision timing to clear lines and climb the ranks.</p>
+              <p>Stack falling pieces as the uniform HUD celebrates every line clear and combo ladder.</p>
             </div>
           </a>
 
-          <a class="game-card card-surface" href="./online-hustle-simulator/" role="listitem" data-status="new">
+          <a
+            class="game-card card-surface frame-stack"
+            href="./online-hustle-simulator/"
+            role="listitem"
+            data-status="new"
+          >
             <span class="card-chip">New</span>
-            <div class="card-thumb" aria-hidden="true">
+            <div class="card-thumb" data-thumb="hustle" aria-hidden="true">
               <img src="./assets/thumbnails/online-hustle.svg" alt="" loading="lazy" />
             </div>
             <div class="card-meta">
               <span>Idle Tycoon</span>
               <h2>Online Hustle Simulator</h2>
-              <p>Upgrade your pixel side gigs, keep the energy meter full, and grow your neon empire.</p>
+              <p>Scale your pixel empire with dashboards that now mirror the arcade cabinet HUD.</p>
             </div>
           </a>
 
-          <a class="game-card card-surface" href="./neon-memory/" role="listitem" data-status="new">
+          <a
+            class="game-card card-surface frame-stack"
+            href="./neon-memory/"
+            role="listitem"
+            data-status="new"
+          >
             <span class="card-chip">New</span>
-            <div class="card-thumb" aria-hidden="true">
+            <div class="card-thumb" data-thumb="memory" aria-hidden="true">
               <img src="./assets/thumbnails/neon-memory.svg" alt="" loading="lazy" />
             </div>
             <div class="card-meta">
               <span>Memory Rush</span>
               <h2>Neon Memory</h2>
-              <p>Flip neon tiles, lock in the pairs, and clear the board before the tempo maxes out.</p>
+              <p>Flip neon tiles with the uniform UI tracking streaks and bonus multipliers.</p>
             </div>
           </a>
+
+          <article
+            class="game-card card-surface frame-stack game-card--upcoming"
+            role="listitem"
+            aria-disabled="true"
+            data-status="upcoming"
+          >
+            <span class="card-chip card-chip--upcoming">Coming soon</span>
+            <div class="card-thumb" data-thumb="drift" aria-hidden="true">
+              <img src="./assets/thumbnails/photon-drift.svg" alt="" loading="lazy" />
+            </div>
+            <div class="card-meta">
+              <span>Hyperloop Racer</span>
+              <h2>Photon Drift</h2>
+              <p>Preview the next cabinet: a gravity-bending racer currently syncing with the new frame.</p>
+            </div>
+          </article>
         </div>
       </main>
 


### PR DESCRIPTION
## Summary
- update the homepage hero copy, ticker, and stats to highlight the unified cabinet UI and the Photon Drift preview
- refresh the game grid cards with gradient thumbnail frames, consistent copy, and a coming-soon placeholder wired to shared layout helpers
- adjust the shuffle script to ignore upcoming cards and add the Photon Drift thumbnail asset

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d94d56a2a8832ca44d61f44f1fc6fe