### PR TITLE
Integrate Petak into shared arcade frame

### DIFF
--- a/petak/index.html
+++ b/petak/index.html
@@ -1,53 +1,85 @@
 <!DOCTYPE html>
 <html lang="sr">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Petak - Srpski Wordle</title>
-  <link rel="stylesheet" href="style.css" />
-</head>
-<body>
-  <main class="game-container">
-    <header class="game-header">
-      <div class="title-group">
-        <h1>Petak</h1>
-        <p class="subtitle">Srpski Wordle, uz malo sjaja ✨</p>
-      </div>
-      <div class="controls">
-        <div class="language-picker">
-          <label for="language-select">Jezik:</label>
-          <select id="language-select"></select>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Petak · Pixel Playground</title>
+    <link rel="stylesheet" href="../arcade.css" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="arcade-page">
+      <header class="arcade-header card-surface">
+        <div class="arcade-header__meta">
+          <span class="brand-title">Pixel Playground</span>
+          <h1>Petak</h1>
+          <p class="subtitle">Srpski Wordle, uz malo sjaja ✨</p>
         </div>
-        <button class="reset-button" id="reset-button" type="button">Nova reč</button>
-      </div>
-    </header>
+        <a class="arcade-back" href="../index.html">
+          <span aria-hidden="true">⟵</span>
+          Povratak u kolekciju
+        </a>
+      </header>
 
-    <section class="status-bar" id="status-bar" role="status" aria-live="polite"></section>
+      <main class="arcade-main">
+        <div class="petak-layout">
+          <section class="arcade-game__frame petak-surface" aria-labelledby="petak-board-title">
+            <div class="petak-frame__body">
+              <h2 id="petak-board-title" class="visually-hidden">Tabla za pogađanje</h2>
+              <div class="board" id="board" aria-live="polite" aria-label="Tabla za pogađanje"></div>
+              <section class="keyboard" id="keyboard" aria-label="Virtuelna tastatura"></section>
+            </div>
+          </section>
 
-    <section class="board" id="board" aria-live="polite" aria-label="Tabla za pogađanje"></section>
+          <div class="arcade-panels">
+            <section class="arcade-panel petak-surface" aria-labelledby="petak-controls-title">
+              <h2 id="petak-controls-title">Kontrole</h2>
+              <div class="controls">
+                <div class="language-picker">
+                  <label for="language-select">Jezik</label>
+                  <select id="language-select"></select>
+                </div>
+                <button class="reset-button" id="reset-button" type="button">Nova reč</button>
+              </div>
+            </section>
 
-    <section class="keyboard" id="keyboard" aria-label="Virtuelna tastatura"></section>
+            <section class="arcade-panel petak-surface" aria-labelledby="petak-status-title">
+              <h2 id="petak-status-title">Status</h2>
+              <p class="status-hint">Poruke igre se pojavljuju ovde tokom svake partije.</p>
+              <div class="status-bar" id="status-bar" role="status" aria-live="polite"></div>
+            </section>
 
-    <details class="instructions">
-      <summary>Kako se igra?</summary>
-      <p>
-        Pogodi skrivenu reč od pet slova za šest pokušaja. Zelena slova su na pravom mestu,
-        žuta su u reči, ali na pogrešnom mestu, dok siva nisu deo reči. Odaberi drugo pismo
-        i listu reči preko menija iznad. Klikni na „Nova reč" za novi izazov.
-      </p>
-    </details>
-  </main>
+            <section class="arcade-panel petak-surface instructions" aria-labelledby="petak-instructions-title">
+              <h2 id="petak-instructions-title">Kako se igra?</h2>
+              <p>
+                Pogodi skrivenu reč od pet slova za šest pokušaja. Zelena slova su na pravom mestu,
+                žuta su u reči, ali na pogrešnom mestu, dok siva nisu deo reči.
+              </p>
+              <p>
+                Odaberi drugo pismo i listu reči preko menija iznad. Klikni na „Nova reč" za novi
+                izazov.
+              </p>
+            </section>
+          </div>
+        </div>
+      </main>
 
-  <template id="board-row-template">
-    <div class="board-row" role="row">
-      <div class="tile" role="gridcell" aria-label="prazno polje"></div>
-      <div class="tile" role="gridcell" aria-label="prazno polje"></div>
-      <div class="tile" role="gridcell" aria-label="prazno polje"></div>
-      <div class="tile" role="gridcell" aria-label="prazno polje"></div>
-      <div class="tile" role="gridcell" aria-label="prazno polje"></div>
+      <footer class="arcade-footer">
+        © <span class="js-year"></span> Pixel Playground · Osvaji pet slova pre nego što pokušaji isteknu.
+      </footer>
     </div>
-  </template>
 
-  <script src="script.js"></script>
-</body>
+    <template id="board-row-template">
+      <div class="board-row" role="row">
+        <div class="tile" role="gridcell" aria-label="prazno polje"></div>
+        <div class="tile" role="gridcell" aria-label="prazno polje"></div>
+        <div class="tile" role="gridcell" aria-label="prazno polje"></div>
+        <div class="tile" role="gridcell" aria-label="prazno polje"></div>
+        <div class="tile" role="gridcell" aria-label="prazno polje"></div>
+      </div>
+    </template>
+
+    <script src="script.js" defer></script>
+    <script src="../assets/js/arcade.js" defer></script>
+  </body>
 </html>

--- a/petak/style.css
+++ b/petak/style.css
@@ -22,104 +22,201 @@
   --status-error: #d64545;
   --shadow: 0 10px 40px rgba(31, 38, 135, 0.12);
   --shadow-dark: 0 12px 36px rgba(0, 0, 0, 0.45);
+  --frame-max-width: 560px;
+  --panel-max-width: 320px;
+  --frame-padding: clamp(1.5rem, 4vw, 2.5rem);
+  --panel-padding: clamp(1.1rem, 3vw, 1.5rem);
+  --layout-gap: clamp(1rem, 3vw, 1.6rem);
 }
 
-@media (prefers-color-scheme: dark) {
-  body {
-    background: radial-gradient(circle at 20% 20%, #1f2231 0%, #0f1016 60%);
-    color: var(--text-dark);
-  }
-  .game-container {
-    background: var(--panel-dark);
-    box-shadow: var(--shadow-dark);
-  }
-  .subtitle {
-    color: rgba(248, 248, 255, 0.7);
-  }
-  .tile {
-    border-color: var(--tile-border-dark);
-  }
-  .keyboard-key {
-    background-color: var(--keyboard-bg-dark);
-    color: var(--keyboard-text-dark);
-  }
-  .keyboard-key:hover,
-  .keyboard-key:focus-visible {
-    background-color: rgba(255, 255, 255, 0.12);
-  }
-  .reset-button {
-    background: rgba(255, 255, 255, 0.08);
-    color: var(--text-dark);
-  }
-  .keyboard {
-    background-color: rgba(255, 255, 255, 0.08);
-  }
-  .instructions {
-    background-color: rgba(255, 255, 255, 0.08);
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
-  }
-  .status-bar {
-    background-color: rgba(90, 116, 255, 0.14);
-  }
-}
-
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
-  font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: clamp(1rem, 3vw, 3rem);
   background: radial-gradient(circle at 20% 20%, #fefefe 0%, #f0f1f6 50%, #e7ebff 100%);
   color: var(--text);
+  font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
-.game-container {
-  width: min(620px, 100%);
-  padding: clamp(1.5rem, 4vw, 2.5rem);
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  background: var(--panel);
-  backdrop-filter: blur(16px);
-  border-radius: 1.5rem;
-  box-shadow: var(--shadow);
-  border: 1px solid rgba(255, 255, 255, 0.4);
-}
-
-.game-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-}
-
-.title-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-}
-
-.game-header h1 {
-  margin: 0;
-  font-size: clamp(2rem, 5vw, 3rem);
-  letter-spacing: 0.2rem;
-  text-transform: uppercase;
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .subtitle {
   margin: 0;
-  font-size: clamp(0.85rem, 2.5vw, 1.05rem);
-  color: rgba(26, 26, 26, 0.65);
+  font-size: clamp(0.95rem, 2.4vw, 1.1rem);
+  color: rgba(26, 26, 26, 0.68);
+}
+
+.petak-layout {
+  display: grid;
+  grid-template-columns: minmax(0, min(100%, var(--frame-max-width)))
+    minmax(0, min(100%, var(--panel-max-width)));
+  gap: var(--layout-gap);
+  align-items: start;
+}
+
+.arcade-main {
+  align-items: stretch;
+}
+
+.petak-surface {
+  background: var(--panel);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(16px);
+}
+
+.arcade-game__frame {
+  padding: var(--frame-padding);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.petak-frame__body {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.board {
+  display: grid;
+  gap: 0.6rem;
+  width: min(100%, 420px);
+  margin: 0 auto;
+}
+
+.board-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.tile {
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+  border: 2px solid rgba(0, 0, 0, 0.12);
+  display: grid;
+  place-items: center;
+  font-size: clamp(1.5rem, 6vw, 2.2rem);
+  font-weight: 700;
+  text-transform: uppercase;
+  border-radius: 0.4rem;
+  background-color: rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.08);
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.tile.filled {
+  border-color: var(--tile-border-dark);
+}
+
+.tile.correct {
+  background-color: var(--correct);
+  border-color: var(--correct);
+  color: #fff;
+}
+
+.tile.present {
+  background-color: var(--present);
+  border-color: var(--present);
+  color: #fff;
+}
+
+.tile.absent {
+  background-color: var(--absent);
+  border-color: var(--absent);
+  color: #fff;
+}
+
+.tile.flip {
+  animation: flip 0.6s ease;
+}
+
+.board-row.active .tile.filled {
+  animation: pop 0.15s ease;
+}
+
+.keyboard {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border-radius: 1rem;
+  background-color: rgba(255, 255, 255, 0.55);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.04);
+  width: min(100%, 480px);
+  margin: 0 auto;
+}
+
+.keyboard-row {
+  display: flex;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+.keyboard-key {
+  flex: 1 1 2.6rem;
+  padding: 0.75rem 0.5rem;
+  background-color: var(--keyboard-bg);
+  color: var(--keyboard-text);
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: transform 0.1s ease, background-color 0.2s ease;
+}
+
+.keyboard-key.wide {
+  flex: 1.5 1 2.6rem;
+}
+
+.keyboard-key:hover,
+.keyboard-key:focus-visible {
+  outline: none;
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.keyboard-key:active {
+  transform: scale(0.95);
+}
+
+.arcade-panels {
+  display: grid;
+  gap: var(--layout-gap);
+}
+
+.arcade-panel {
+  padding: var(--panel-padding);
+  display: grid;
+  gap: 1rem;
+}
+
+.arcade-panel h2 {
+  margin: 0;
+  font-size: 1.1rem;
 }
 
 .controls {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.75rem;
 }
@@ -130,9 +227,13 @@ body {
   gap: 0.5rem;
 }
 
+.language-picker label {
+  font-weight: 600;
+}
+
 .language-picker select {
   padding: 0.45rem 0.75rem;
-  border-radius: 0.6rem;
+  border-radius: 0.75rem;
   border: 1px solid rgba(0, 0, 0, 0.1);
   background-color: rgba(255, 255, 255, 0.9);
   font-size: 1rem;
@@ -147,11 +248,11 @@ body {
 }
 
 .reset-button {
-  padding: 0.55rem 0.95rem;
-  border-radius: 0.75rem;
+  padding: 0.6rem 1rem;
+  border-radius: 0.85rem;
   border: none;
   background: linear-gradient(135deg, var(--accent), #8f8afc);
-  color: white;
+  color: #fff;
   font-weight: 600;
   cursor: pointer;
   box-shadow: 0 6px 14px rgba(103, 86, 246, 0.35);
@@ -163,6 +264,16 @@ body {
   outline: none;
   transform: translateY(-1px);
   box-shadow: 0 10px 18px rgba(103, 86, 246, 0.45);
+}
+
+.status-hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(26, 26, 26, 0.65);
+}
+
+.arcade-panel:has(.status-bar.visible) .status-hint {
+  display: none;
 }
 
 .status-bar {
@@ -194,134 +305,17 @@ body {
   color: var(--status-error);
 }
 
-.board {
-  display: grid;
-  gap: 0.6rem;
-}
-
-.board-row {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 0.5rem;
-}
-
-.tile {
-  position: relative;
-  width: 100%;
-  padding-top: 100%;
-  border: 2px solid rgba(0, 0, 0, 0.12);
-  display: grid;
-  place-items: center;
-  font-size: clamp(1.5rem, 6vw, 2.2rem);
-  font-weight: 700;
-  text-transform: uppercase;
-  border-radius: 0.4rem;
-  background-color: rgba(255, 255, 255, 0.6);
-  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.08);
-  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
-}
-
-.tile.filled {
-  border-color: var(--tile-border-dark);
-}
-
-.tile.flip {
-  animation: flip 0.6s ease;
-}
-
-.board-row.active .tile.filled {
-  animation: pop 0.15s ease;
-}
-
-.tile.correct {
-  background-color: var(--correct);
-  border-color: var(--correct);
-  color: white;
-}
-
-.tile.present {
-  background-color: var(--present);
-  border-color: var(--present);
-  color: white;
-}
-
-.tile.absent {
-  background-color: var(--absent);
-  border-color: var(--absent);
-  color: white;
-}
-
-.keyboard {
-  display: grid;
-  gap: 0.5rem;
-  padding: 0.6rem;
-  border-radius: 1rem;
-  background-color: rgba(255, 255, 255, 0.55);
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.04);
-}
-
-.keyboard-row {
-  display: flex;
-  justify-content: center;
-  gap: 0.4rem;
-}
-
-.keyboard-key {
-  padding: 0.75rem;
-  background-color: var(--keyboard-bg);
-  color: var(--keyboard-text);
-  border: none;
-  border-radius: 0.4rem;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  text-transform: uppercase;
-  min-width: 2.6rem;
-  transition: transform 0.1s ease, background-color 0.2s ease;
-}
-
-.keyboard-key:active {
-  transform: scale(0.95);
-}
-
-.keyboard-key:hover,
-.keyboard-key:focus-visible {
-  outline: none;
-  background-color: rgba(0, 0, 0, 0.08);
-}
-
-.keyboard-key.wide {
-  min-width: 4rem;
-}
-
 .instructions {
-  margin: 0;
   font-size: 0.95rem;
-  line-height: 1.5;
-  background-color: rgba(255, 255, 255, 0.55);
-  padding: 1rem 1.2rem;
-  border-radius: 1rem;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.04);
+  line-height: 1.6;
 }
 
-.instructions summary {
-  font-weight: 700;
-  cursor: pointer;
-  list-style: none;
+.instructions p {
+  margin: 0;
 }
 
-.instructions summary::-webkit-details-marker {
-  display: none;
-}
-
-.instructions summary::after {
-  content: "+";
-  float: right;
-  transition: transform 0.3s ease;
-}
-
-.instructions[open] summary::after {
-  transform: rotate(45deg);
+.instructions p + p {
+  margin-top: 0.75rem;
 }
 
 .shake {
@@ -375,18 +369,103 @@ body {
   }
 }
 
-@media (max-width: 600px) {
-  .game-container {
-    padding: 1.25rem;
+@media (prefers-color-scheme: dark) {
+  body {
+    background: radial-gradient(circle at 20% 20%, #1f2231 0%, #0f1016 60%);
+    color: var(--text-dark);
+  }
+
+  .subtitle,
+  .status-hint {
+    color: rgba(248, 248, 255, 0.7);
+  }
+
+  .petak-surface {
+    background: var(--panel-dark);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: var(--shadow-dark);
+  }
+
+  .language-picker select {
+    border-color: rgba(255, 255, 255, 0.16);
+    background-color: rgba(24, 24, 30, 0.85);
+    color: var(--text-dark);
+  }
+
+  .tile {
+    border-color: var(--tile-border-dark);
+    background-color: rgba(22, 22, 28, 0.85);
+    box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.45);
+  }
+
+  .keyboard {
+    background-color: rgba(255, 255, 255, 0.08);
   }
 
   .keyboard-key {
-    min-width: 2.4rem;
-    padding: 0.6rem 0.4rem;
+    background-color: var(--keyboard-bg-dark);
+    color: var(--keyboard-text-dark);
+  }
+
+  .keyboard-key:hover,
+  .keyboard-key:focus-visible {
+    background-color: rgba(255, 255, 255, 0.12);
+  }
+
+  .reset-button {
+    background: linear-gradient(135deg, var(--accent-dark), #9a93ff);
+    color: var(--text-dark);
+  }
+
+  .status-bar {
+    background-color: rgba(90, 116, 255, 0.14);
+  }
+}
+
+@media (max-width: 960px) {
+  .petak-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .arcade-panels {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .arcade-panels {
+    grid-template-columns: 1fr;
   }
 
   .controls {
     flex-direction: column;
-    align-items: flex-end;
+    align-items: stretch;
+  }
+
+  .language-picker {
+    justify-content: space-between;
+  }
+
+  .language-picker select,
+  .reset-button {
+    width: 100%;
+  }
+
+  .keyboard {
+    padding: 0.6rem;
+    gap: 0.4rem;
+  }
+
+  .keyboard-row {
+    gap: 0.3rem;
+  }
+
+  .keyboard-key {
+    font-size: 0.95rem;
+    padding: 0.65rem 0.4rem;
+  }
+
+  .keyboard-key.wide {
+    flex: 1.65 1 2.6rem;
   }
 }


### PR DESCRIPTION
## Summary
- wrap the Petak page with the shared arcade header/footer and split the layout between the game frame and info panels
- refactor page styling to rely on shared frame variables while keeping the custom tile and keyboard theming
- update responsive rules so the stacked layout preserves a comfortable on-screen keyboard on mobile widths

## Testing
- Manual QA in browser

------
https://chatgpt.com/codex/tasks/task_e_68d94d4cd294832cbbd6b1a44d89d0de