### PR TITLE
Refactor Online Hustle Simulator to use arcade shell

### DIFF
--- a/online-hustle-simulator/index.html
+++ b/online-hustle-simulator/index.html
@@ -3,68 +3,91 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Online Hustle Simulator</title>
+  <title>Online Hustle Simulator · Pixel Playground</title>
+  <link rel="stylesheet" href="../arcade.css" />
   <link rel="stylesheet" href="styles.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
-  <div class="app">
-    <header class="top-bar">
-      <div class="stat">
-        <span class="label">Money</span>
-        <span id="money" class="value">$0</span>
+  <div class="arcade-page">
+    <header class="arcade-header card-surface">
+      <div class="arcade-header__meta">
+        <span class="brand-title">Pixel Playground</span>
+        <h1>Online Hustle Simulator</h1>
+        <p>Flip, freelance, and automate your way from broke to balling before the day ends.</p>
       </div>
-      <div class="stat time">
-        <span class="label">Time Left</span>
-        <div class="time-wrapper">
-          <span id="time" class="value">14h</span>
-          <div class="time-bar">
-            <div id="time-progress" class="time-progress"></div>
-          </div>
-        </div>
-      </div>
-      <div class="stat">
-        <span class="label">Day</span>
-        <span id="day" class="value">1</span>
-      </div>
-      <button id="end-day" class="end-day">End Day</button>
+      <a class="arcade-back" href="../index.html">
+        <span aria-hidden="true">⟵</span>
+        Back to Arcade
+      </a>
     </header>
 
-    <main>
-      <section class="panel hustles">
-        <div class="panel-header">
-          <h2>Daily Hustles</h2>
-          <p>Spend your time wisely. When the clock hits zero, the grind resets.</p>
-        </div>
-        <div class="card-grid" id="hustle-grid"></div>
-      </section>
+    <main class="arcade-main">
+      <div class="arcade-game hustle-sim">
+        <section class="arcade-game__stage">
+          <header class="stage-status">
+            <div class="stat">
+              <span class="label">Money</span>
+              <span id="money" class="value">$0</span>
+            </div>
+            <div class="stat time">
+              <span class="label">Time Left</span>
+              <div class="time-wrapper">
+                <span id="time" class="value">14h</span>
+                <div class="time-bar">
+                  <div id="time-progress" class="time-progress"></div>
+                </div>
+              </div>
+            </div>
+            <div class="stat">
+              <span class="label">Day</span>
+              <span id="day" class="value">1</span>
+            </div>
+            <button id="end-day" class="end-day">End Day</button>
+          </header>
 
-      <section class="panel assets">
-        <div class="panel-header">
-          <h2>Passive Assets</h2>
-          <p>Build long-term plays that keep the cash flowing even when you log off.</p>
-        </div>
-        <div class="card-grid" id="asset-grid"></div>
-      </section>
+          <div class="stage-panel">
+            <div class="stage-panel__header">
+              <h2>Daily Hustles</h2>
+              <p>Spend your time wisely. When the clock hits zero, the grind resets.</p>
+            </div>
+            <div class="card-grid" id="hustle-grid"></div>
+          </div>
+        </section>
 
-      <section class="panel upgrades">
-        <div class="panel-header">
-          <h2>Upgrades & Boosts</h2>
-          <p>Invest in yourself to push the grind further.</p>
-        </div>
-        <div class="card-grid" id="upgrade-grid"></div>
-      </section>
+        <aside class="arcade-game__sidebar">
+          <section class="arcade-panel">
+            <div class="arcade-panel__header">
+              <h2>Passive Assets</h2>
+              <p>Build long-term plays that keep the cash flowing even when you log off.</p>
+            </div>
+            <div class="card-grid" id="asset-grid"></div>
+          </section>
 
-      <section class="panel log">
-        <div class="panel-header">
-          <h2>Event Log</h2>
-          <p id="log-tip">Welcome! Start hustling to fill your feed.</p>
-        </div>
-        <div id="log-feed" class="log-feed"></div>
-      </section>
+          <section class="arcade-panel">
+            <div class="arcade-panel__header">
+              <h2>Upgrades &amp; Boosts</h2>
+              <p>Invest in yourself to push the grind further.</p>
+            </div>
+            <div class="card-grid" id="upgrade-grid"></div>
+          </section>
+
+          <section class="arcade-panel">
+            <div class="arcade-panel__header">
+              <h2>Event Log</h2>
+              <p id="log-tip">Welcome! Start hustling to fill your feed.</p>
+            </div>
+            <div id="log-feed" class="log-feed"></div>
+          </section>
+        </aside>
+      </div>
     </main>
+
+    <footer class="arcade-footer">
+      © <span class="js-year"></span> Pixel Playground · Keep hustling until the inbox is empty.
+    </footer>
   </div>
 
   <template id="log-template">
@@ -75,5 +98,6 @@
   </template>
 
   <script src="script.js"></script>
+  <script src="../assets/js/arcade.js" defer></script>
 </body>
 </html>

--- a/online-hustle-simulator/styles.css
+++ b/online-hustle-simulator/styles.css
@@ -10,7 +10,6 @@
   --warning: #f97316;
   --danger: #f87171;
   --shadow: 0 16px 30px rgba(15, 23, 42, 0.2);
-  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 * {
@@ -23,27 +22,35 @@ body {
   min-height: 100vh;
   background: radial-gradient(circle at 10% 20%, #1e293b 0%, #0f172a 45%, #020617 100%);
   color: var(--text);
-  display: flex;
-  justify-content: center;
-  padding: 2rem 1rem 3rem;
 }
 
-.app {
-  width: min(1100px, 100%);
+.hustle-sim {
+  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--text);
+}
+
+.arcade-game {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.42fr);
+  gap: clamp(1.5rem, 3vw, 2rem);
+  align-items: start;
+}
+
+.arcade-game__stage {
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  border-radius: 26px;
+  background: var(--panel-bg);
+  backdrop-filter: blur(22px);
+  box-shadow: var(--shadow);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
 }
 
-.top-bar {
+.stage-status {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1rem;
-  background: var(--panel-bg);
-  backdrop-filter: blur(20px);
-  padding: 1rem 1.25rem;
-  border-radius: 18px;
-  box-shadow: var(--shadow);
   align-items: center;
 }
 
@@ -61,7 +68,7 @@ body {
 }
 
 .stat .value {
-  font-size: 1.6rem;
+  font-size: clamp(1.4rem, 2vw, 1.65rem);
   font-weight: 700;
   color: var(--text);
   transition: color 0.3s ease;
@@ -119,30 +126,18 @@ body {
   transform: translateY(-2px);
 }
 
-main {
+.stage-panel {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
-.panel {
-  background: var(--panel-bg);
-  border-radius: 24px;
-  padding: 1.5rem;
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(18px);
+.stage-panel__header h2 {
+  font-size: clamp(1.5rem, 3vw, 1.75rem);
+  margin-bottom: 0.35rem;
 }
 
-.panel-header {
-  margin-bottom: 1rem;
-}
-
-.panel-header h2 {
-  font-size: 1.6rem;
-  margin-bottom: 0.2rem;
-}
-
-.panel-header p {
+.stage-panel__header p {
   color: var(--muted);
   font-size: 0.95rem;
 }
@@ -279,6 +274,33 @@ main {
   color: var(--muted);
 }
 
+.arcade-game__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.arcade-panel {
+  background: var(--panel-bg);
+  border-radius: 24px;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.arcade-panel__header h2 {
+  font-size: clamp(1.35rem, 2.5vw, 1.6rem);
+  margin-bottom: 0.35rem;
+}
+
+.arcade-panel__header p {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
 .log-feed {
   display: flex;
   flex-direction: column;
@@ -331,17 +353,29 @@ main {
   border-left-color: var(--warning);
 }
 
-@media (max-width: 768px) {
-  body {
-    padding: 1.5rem 0.75rem 2.5rem;
+@media (max-width: 1100px) {
+  .arcade-game {
+    grid-template-columns: 1fr;
   }
 
-  .top-bar {
-    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  .arcade-game__sidebar {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    background: radial-gradient(circle at 20% 10%, #1e293b 0%, #0f172a 45%, #020617 100%);
+  }
+
+  .stage-status {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: 0.75rem;
   }
 
-  .panel {
+  .arcade-panel,
+  .arcade-game__stage {
     padding: 1.25rem;
   }
 
@@ -354,13 +388,18 @@ main {
   }
 }
 
-@media (max-width: 480px) {
-  .top-bar {
-    grid-template-columns: 1fr 1fr;
+@media (max-width: 600px) {
+  .stage-status {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .end-day {
+  .stage-status .end-day {
     grid-column: 1 / -1;
+    justify-self: stretch;
     width: 100%;
+  }
+
+  .arcade-game__sidebar {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- wrap the Online Hustle Simulator with the shared arcade header, footer, and layout scaffolding
- move passive assets, upgrades, and log panels into sidebar arcade cards with refreshed styling
- refine responsive behavior so the sidebar stacks under the hustles stage and primary actions widen on mobile

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d94d541ff0832ca8eddd1c05cb08bc