### PR TITLE
Refine Tetris layout for arcade shell

### DIFF
--- a/tetris_knockoff/index.html
+++ b/tetris_knockoff/index.html
@@ -22,13 +22,19 @@
       </header>
 
       <main class="arcade-main">
-        <section class="wrapper" aria-labelledby="block-drop-title">
-          <section class="game-panel">
-            <header>
+        <section class="arcade-game" aria-labelledby="block-drop-title">
+          <div class="arcade-game__frame">
+            <header class="arcade-game__intro">
               <h2 id="block-drop-title">Block Drop</h2>
               <p>Use the arrow keys or WASD to move, rotate, and drop pieces.</p>
             </header>
-            <canvas id="board" width="300" height="600" aria-label="Tetris playfield" role="img"></canvas>
+            <canvas
+              id="board"
+              width="300"
+              height="600"
+              aria-label="Tetris playfield"
+              role="img"
+            ></canvas>
             <div class="hud" role="status" aria-live="polite">
               <div class="stat">
                 <span class="label">Score</span>
@@ -44,19 +50,26 @@
               </div>
             </div>
             <button id="restart" type="button" class="button">Restart</button>
-          </section>
-          <aside class="next-panel">
-            <h2>Next</h2>
-            <canvas id="next" width="120" height="120" aria-label="Next tetromino preview"></canvas>
-            <section class="instructions">
+          </div>
+          <aside class="arcade-game__sidebar">
+            <div class="arcade-panel">
+              <h2>Next</h2>
+              <canvas
+                id="next"
+                width="120"
+                height="120"
+                aria-label="Next tetromino preview"
+              ></canvas>
+            </div>
+            <div class="arcade-panel">
               <h3>Controls</h3>
-              <ul>
+              <ul class="controls-list">
                 <li><strong>Move</strong>: Left / Right arrows or A / D</li>
                 <li><strong>Rotate</strong>: Up arrow or W</li>
                 <li><strong>Soft Drop</strong>: Down arrow or S</li>
                 <li><strong>Hard Drop</strong>: Space</li>
               </ul>
-            </section>
+            </div>
           </aside>
         </section>
       </main>

--- a/tetris_knockoff/styles.css
+++ b/tetris_knockoff/styles.css
@@ -1,82 +1,103 @@
 :root {
-  --bg: #0f172a;
   --panel: #1e293b;
   --panel-light: #273349;
   --accent: #fbbf24;
   --text: #e2e8f0;
   --grid: rgba(148, 163, 184, 0.2);
+  --board-cols: 10;
+  --board-rows: 20;
+  --board-cell: 30px;
+  --board-width: calc(var(--board-cols) * var(--board-cell));
+  --board-height: calc(var(--board-rows) * var(--board-cell));
+  --panel-radius: 1rem;
+  --panel-padding: clamp(1.5rem, 3vw, 2rem);
   font-family: 'Poppins', 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-body {
-  margin: 0;
-  min-height: 100vh;
-  background: var(--brand-bg, radial-gradient(circle at top, #1e293b, #0f172a));
-  color: var(--text);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: clamp(1.5rem, 4vw, 3rem);
 }
 
 .arcade-main {
   align-items: stretch;
 }
 
-.wrapper {
+.arcade-game {
   display: grid;
-  gap: 2rem;
-  grid-template-columns: minmax(280px, 1fr) minmax(180px, 240px);
-  width: min(100%, 900px);
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+  align-items: start;
 }
 
-.game-panel,
-.next-panel {
+.arcade-game__frame,
+.arcade-panel {
   background: var(--panel);
-  border-radius: 1rem;
-  padding: 1.5rem;
+  border-radius: var(--panel-radius);
+  padding: var(--panel-padding);
   box-shadow: 0 1rem 2rem rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  color: var(--text);
 }
 
-h1,
-h2,
-h3 {
-  margin: 0 0 0.5rem;
+.arcade-game__frame {
+  display: grid;
+  justify-items: stretch;
+  gap: 1.5rem;
+}
+
+.arcade-game__intro {
+  text-align: center;
+}
+
+.arcade-game__intro h2 {
+  margin: 0 0 0.35rem;
   font-weight: 600;
 }
 
-.game-panel header p {
-  margin: 0 0 1.5rem;
-  color: rgba(226, 232, 240, 0.7);
+.arcade-game__intro p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.75);
+  font-size: 0.95rem;
 }
 
 canvas {
   display: block;
-  margin: 0 auto;
+}
+
+#board {
+  justify-self: center;
+  width: var(--board-width);
+  height: var(--board-height);
   background: var(--panel-light);
   border-radius: 0.75rem;
   box-shadow: inset 0 0 1.5rem rgba(15, 23, 42, 0.8);
 }
 
+#next {
+  margin-inline: auto;
+  width: calc(4 * var(--board-cell));
+  height: calc(4 * var(--board-cell));
+  background: var(--panel-light);
+  border-radius: 0.75rem;
+  box-shadow: inset 0 0 1.25rem rgba(15, 23, 42, 0.7);
+}
+
 .hud {
-  display: flex;
-  justify-content: space-between;
-  margin: 1.5rem 0 1rem;
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: 1rem;
+  margin: 0;
 }
 
 .stat {
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.35rem;
+  text-align: center;
 }
 
 .label {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: rgba(226, 232, 240, 0.6);
@@ -100,19 +121,27 @@ canvas {
 }
 
 .button:hover,
-.button:focus {
+.button:focus-visible {
   transform: translateY(-2px);
   box-shadow: 0 0.75rem 1.5rem rgba(249, 115, 22, 0.5);
 }
 
-.next-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+.arcade-game__sidebar {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.arcade-panel h2,
+.arcade-panel h3 {
+  margin: 0 0 1rem;
+  font-weight: 600;
+}
+
+.arcade-panel h2 {
   text-align: center;
 }
 
-.instructions ul {
+.controls-list {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -120,19 +149,43 @@ canvas {
   gap: 0.5rem;
 }
 
-.instructions li {
+.controls-list li {
   background: rgba(148, 163, 184, 0.1);
   border-radius: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  font-size: 0.9rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
 }
 
-@media (max-width: 768px) {
-  body {
-    padding: 1.5rem 1rem;
+@media (min-width: 860px) {
+  .arcade-game {
+    grid-template-columns: auto minmax(220px, 280px);
+  }
+}
+
+@media (max-width: 640px) {
+  .arcade-game__frame {
+    justify-items: stretch;
   }
 
-  .wrapper {
-    grid-template-columns: 1fr;
+  .arcade-game__intro {
+    text-align: left;
+  }
+
+  #board {
+    margin-inline: auto;
+  }
+}
+
+@media (max-width: 500px) {
+  :root {
+    --board-cell: 24px;
+  }
+
+  .hud {
+    gap: 0.75rem;
+  }
+
+  .stat {
+    padding: 0.65rem;
   }
 }


### PR DESCRIPTION
## Summary
- reorganized the Block Drop markup to use the arcade frame/sidebar pattern with dedicated panels for the preview and controls
- refreshed the Tetris styles to share sizing variables, drop the legacy wrapper grid, and align stats/control styling with the arcade shell

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d94d5822d8832cb737005451d77c9b