### PR TITLE
Fix 2048 layout, add runner mobile controls, and expand simple mover

### DIFF
--- a/2048/style.css
+++ b/2048/style.css
@@ -18,9 +18,6 @@
   --arcade-stage-width: min(92vw, 520px);
   --board-padding: clamp(1rem, 3vw, 1.75rem);
   --tile-gap: clamp(0.5rem, 1.5vw, 1rem);
-  --tile-size: calc(
-    (var(--arcade-stage-width) - 2 * var(--board-padding) - 3 * var(--tile-gap)) / 4
-  );
   display: grid;
   gap: clamp(1.5rem, 3vw, 2.5rem);
   align-items: start;
@@ -34,6 +31,11 @@
   background: radial-gradient(circle at top, #f5efff 0%, #f0f4ff 45%, #f9f5ff 100%);
   border: 1px solid var(--panel-border);
   box-shadow: 0 2.5rem 4.5rem rgba(78, 61, 158, 0.18);
+  aspect-ratio: auto;
+  height: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .arcade-game__frame {
@@ -41,6 +43,7 @@
   margin: 0 auto;
   display: grid;
   gap: clamp(1.5rem, 3vw, 2.5rem);
+  position: relative;
 }
 
 .game-brief {
@@ -61,6 +64,8 @@
 }
 
 .board {
+  --playfield-size: calc(100% - 2 * var(--board-padding));
+  --tile-size: calc((var(--playfield-size) - 3 * var(--tile-gap)) / 4);
   position: relative;
   width: 100%;
   max-width: var(--arcade-stage-width);
@@ -74,35 +79,32 @@
 }
 
 .grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--tile-gap);
   position: relative;
-  width: 100%;
-  aspect-ratio: 1 / 1;
+  width: var(--playfield-size);
+  height: var(--playfield-size);
   margin: 0 auto;
 }
 
 .grid-row {
-  display: flex;
-  gap: var(--tile-gap);
-  margin-bottom: var(--tile-gap);
-}
-
-.grid-row:last-child {
-  margin-bottom: 0;
+  display: contents;
 }
 
 .grid-cell {
-  flex: 1;
   background: rgba(142, 124, 255, 0.12);
   border-radius: 1rem;
   box-shadow: inset 0 0 0 1px rgba(137, 97, 255, 0.12);
+  aspect-ratio: 1 / 1;
 }
 
 .tile-container {
   position: absolute;
   top: var(--board-padding);
   left: var(--board-padding);
-  width: calc(var(--tile-size) * 4 + var(--tile-gap) * 3);
-  height: calc(var(--tile-size) * 4 + var(--tile-gap) * 3);
+  width: var(--playfield-size);
+  height: var(--playfield-size);
   pointer-events: none;
   overflow: visible;
 }

--- a/endless-runner/index.html
+++ b/endless-runner/index.html
@@ -32,6 +32,28 @@
                 role="img"
                 aria-label="Endless runner game"
               ></canvas>
+              <div
+                id="game-overlay"
+                class="game-overlay hidden"
+                role="status"
+                aria-live="assertive"
+              >
+                <div class="game-overlay__panel">
+                  <h2 class="game-overlay__title">Game Over</h2>
+                  <p class="game-overlay__text">Tap restart to chase a new high score.</p>
+                  <button id="overlay-restart" type="button" class="hud-button">
+                    Restart
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div class="touch-controls" aria-label="Touch controls">
+              <button type="button" class="touch-button touch-button--jump" data-action="jump">
+                Jump
+              </button>
+              <button type="button" class="touch-button touch-button--duck" data-action="duck">
+                Duck
+              </button>
             </div>
           </div>
 

--- a/endless-runner/style.css
+++ b/endless-runner/style.css
@@ -38,7 +38,10 @@ body {
   border: 1px solid var(--runner-border-soft);
   box-shadow: 0 1.5rem 3.5rem rgba(5, 2, 15, 0.75), 0 0 1.35rem rgba(255, 43, 214, 0.2);
   display: flex;
+  flex-direction: column;
   justify-content: center;
+  align-items: center;
+  gap: clamp(1rem, 2.5vw, 1.5rem);
 }
 
 .arcade-game__frame {
@@ -48,12 +51,93 @@ body {
   box-shadow: 0 1.25rem 2.75rem rgba(5, 2, 15, 0.7), 0 0 1.2rem rgba(57, 255, 20, 0.35);
   background: linear-gradient(180deg, #12062b 0%, #04010e 100%);
   overflow: hidden;
+  position: relative;
 }
 
 canvas {
   display: block;
   width: 100%;
   height: auto;
+}
+
+.game-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(1rem, 3vw, 1.75rem);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  text-align: center;
+  background: rgba(5, 2, 15, 0.82);
+  backdrop-filter: blur(6px);
+}
+
+.game-overlay.hidden {
+  display: none;
+}
+
+.game-overlay__panel {
+  display: grid;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  max-width: min(24rem, 90%);
+}
+
+.game-overlay__title {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  color: var(--runner-highlight);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.game-overlay__text {
+  margin: 0;
+  color: rgba(248, 247, 255, 0.8);
+  line-height: 1.6;
+}
+
+.touch-controls {
+  display: none;
+  width: 100%;
+  max-width: min(var(--arcade-stage-width), 100%);
+  justify-content: center;
+  gap: clamp(1rem, 5vw, 2rem);
+}
+
+.touch-button {
+  flex: 1;
+  font: inherit;
+  font-size: clamp(1rem, 4vw, 1.25rem);
+  padding: clamp(0.85rem, 4vw, 1.2rem);
+  border-radius: 999px;
+  border: 1px solid var(--runner-border);
+  color: var(--runner-text);
+  box-shadow: 0 1rem 2.5rem rgba(5, 2, 15, 0.6);
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  touch-action: manipulation;
+  user-select: none;
+}
+
+.touch-button--jump {
+  background: linear-gradient(135deg, rgba(57, 255, 20, 0.35), rgba(57, 255, 20, 0.18));
+}
+
+.touch-button--duck {
+  background: linear-gradient(135deg, rgba(255, 43, 214, 0.32), rgba(255, 43, 214, 0.18));
+}
+
+.touch-button:active {
+  transform: scale(0.97);
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .touch-controls {
+    display: flex;
+  }
 }
 
 .arcade-game__sidebar {

--- a/simple_mover/index.html
+++ b/simple_mover/index.html
@@ -26,8 +26,8 @@
         <section class="arcade-game__frame">
           <canvas
             id="game"
-            width="1200"
-            height="720"
+            width="1440"
+            height="900"
             aria-label="Simple mover game"
             role="img"
           ></canvas>

--- a/simple_mover/script.js
+++ b/simple_mover/script.js
@@ -18,7 +18,7 @@ const state = {
   player: {
     x: 0,
     y: 0,
-    size: 36,
+    size: 44,
     color: "#4db5ff",
     speed: 220,
     dashSpeed: 400,
@@ -393,6 +393,72 @@ function updatePlayer(delta) {
   }
 }
 
+function drawPlayer() {
+  const p = state.player;
+  const size = p.size;
+  const half = size / 2;
+  const centerX = p.x + half;
+  const centerY = p.y + half;
+  const now = performance.now ? performance.now() : Date.now();
+  const pulse = Math.sin(now / 220) * (size * 0.04);
+  const leanRight = state.keys.has("ArrowRight") || state.keys.has("d");
+  const leanLeft = state.keys.has("ArrowLeft") || state.keys.has("a");
+  const tilt = (leanRight ? 1 : 0) - (leanLeft ? 1 : 0);
+
+  ctx.save();
+  ctx.translate(centerX, centerY);
+  ctx.rotate(tilt * 0.15);
+
+  const glow = ctx.createRadialGradient(0, 0, size * 0.15, 0, 0, size * 0.6 + pulse);
+  glow.addColorStop(0, "rgba(77, 181, 255, 0.9)");
+  glow.addColorStop(1, "rgba(77, 181, 255, 0)");
+  ctx.fillStyle = glow;
+  ctx.beginPath();
+  ctx.arc(0, 0, size * 0.6 + pulse, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = "#4db5ff";
+  ctx.beginPath();
+  ctx.moveTo(0, -half * 0.95);
+  ctx.lineTo(half * 0.75, half * 0.6);
+  ctx.lineTo(-half * 0.75, half * 0.6);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = "rgba(9, 22, 38, 0.65)";
+  ctx.beginPath();
+  ctx.moveTo(0, -half * 0.55);
+  ctx.quadraticCurveTo(half * 0.4, half * 0.2, 0, half * 0.45);
+  ctx.quadraticCurveTo(-half * 0.4, half * 0.2, 0, -half * 0.55);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = "#f2fbff";
+  ctx.beginPath();
+  ctx.ellipse(0, -half * 0.18, half * 0.35, half * 0.45, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = "rgba(77, 181, 255, 0.35)";
+  ctx.beginPath();
+  ctx.ellipse(0, -half * 0.16, half * 0.25, half * 0.32, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  const thrusterBase = half * 0.55;
+  const thrusterLength = half * 0.35 + pulse * 0.6;
+  const thruster = ctx.createLinearGradient(0, thrusterBase, 0, thrusterBase + thrusterLength);
+  thruster.addColorStop(0, "rgba(255, 174, 94, 0.85)");
+  thruster.addColorStop(1, "rgba(255, 109, 132, 0.6)");
+  ctx.fillStyle = thruster;
+  ctx.beginPath();
+  ctx.moveTo(-half * 0.32, thrusterBase);
+  ctx.lineTo(0, thrusterBase + thrusterLength);
+  ctx.lineTo(half * 0.32, thrusterBase);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.restore();
+}
+
 function draw() {
   ctx.fillStyle = "#030712";
   ctx.fillRect(0, 0, canvas.width, canvas.height);
@@ -406,9 +472,7 @@ function draw() {
     ctx.fillRect(wall.x, wall.y, wall.width, wall.height);
   });
 
-  const p = state.player;
-  ctx.fillStyle = p.color;
-  ctx.fillRect(p.x, p.y, p.size, p.size);
+  drawPlayer();
 
   if (state.star) {
     ctx.save();

--- a/simple_mover/styles.css
+++ b/simple_mover/styles.css
@@ -3,7 +3,7 @@
   font-family: 'Poppins', 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background-color: #080820;
   color: #f0f6ff;
-  --arcade-stage-width: min(100%, 85rem);
+  --arcade-stage-width: min(100%, 95rem);
 }
 
 body {
@@ -22,7 +22,7 @@ body {
 
 .arcade-game {
   display: grid;
-  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  grid-template-columns: minmax(0, 5fr) minmax(0, 2fr);
   gap: clamp(1.5rem, 4vw, 2.5rem);
   align-items: start;
 }


### PR DESCRIPTION
## Summary
- center the 2048 playfield within its frame and keep tiles within the board
- add a centered overlay and touch controls to the endless runner for better mobile play
- enlarge the simple mover arena and draw a new thruster-style player avatar

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d95e28d828832ca96b8f940c6d433c