### PR TITLE
Add Phase Pulse lane-shifting arcade game

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A collection of bite-sized JavaScript arcade games wrapped in a unified retro ae
 | [Endless Runner](./endless-runner/) | Action | Dash through synthwave streets, avoiding obstacles to extend your run. |
 | [Simple Mover](./simple_mover/) | Arcade trainer | Collect stars, dash through gaps, and dodge reactive walls. |
 | [Block Drop](./tetris_knockoff/) | Falling blocks | Rotate and stack tetrominoes to clear lines and level up. |
+| [Phase Pulse](./phase-pulse/) | Lane flux duel | Shift lanes to harvest pulses, dodge mines, and keep the streak alive. |
 | [Photon Trails](./photon-trails/) | Light puzzle | Rotate mirrors and splitters to connect every drifting crystal. |
 | [Petak](./petak/) | Word puzzle | Guess the hidden Serbian five-letter word with adaptive neon hints. |
 

--- a/assets/thumbnails/phase-pulse.svg
+++ b/assets/thumbnails/phase-pulse.svg
@@ -1,0 +1,57 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" rx="46" fill="url(#bg)" />
+  <g filter="url(#glow)">
+    <circle cx="84" cy="96" r="38" fill="url(#pulse)" fill-opacity="0.9" />
+  </g>
+  <g filter="url(#glow2)">
+    <circle cx="176" cy="160" r="34" fill="#FF5C97" fill-opacity="0.85" />
+  </g>
+  <path
+    d="M32 128C32 116.954 40.9543 108 52 108H204C215.046 108 224 116.954 224 128C224 139.046 215.046 148 204 148H52C40.9543 148 32 139.046 32 128Z"
+    fill="url(#beam)"
+    fill-opacity="0.6"
+  />
+  <path
+    d="M44 128C44 123.582 47.5817 120 52 120H204C208.418 120 212 123.582 212 128C212 132.418 208.418 136 204 136H52C47.5817 136 44 132.418 44 128Z"
+    fill="url(#beamCore)"
+  />
+  <g filter="url(#glow3)">
+    <path
+      d="M128 64C145.673 64 160 78.3269 160 96C160 113.673 145.673 128 128 128C110.327 128 96 113.673 96 96C96 78.3269 110.327 64 128 64Z"
+      stroke="#7BFFFE"
+      stroke-width="10"
+      stroke-linecap="round"
+      stroke-dasharray="22 18"
+    />
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="36" y1="26" x2="220" y2="230" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#05091F" />
+      <stop offset="1" stop-color="#0A132C" />
+    </linearGradient>
+    <linearGradient id="beam" x1="32" y1="128" x2="224" y2="128" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6EE7FF" stop-opacity="0" />
+      <stop offset="0.5" stop-color="#6EE7FF" />
+      <stop offset="1" stop-color="#6EE7FF" stop-opacity="0" />
+    </linearGradient>
+    <linearGradient id="beamCore" x1="44" y1="128" x2="212" y2="128" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7BFFFE" stop-opacity="0" />
+      <stop offset="0.5" stop-color="#7BFFFE" />
+      <stop offset="1" stop-color="#7BFFFE" stop-opacity="0" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="rotate(45 11.5 138.5) scale(56)">
+      <stop stop-color="#FFFFFF" />
+      <stop offset="0.42" stop-color="#7BFFFE" />
+      <stop offset="1" stop-color="#7BFFFE" stop-opacity="0" />
+    </radialGradient>
+    <filter id="glow" x="14" y="26" width="140" height="140" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="12" result="effect1_foregroundBlur" />
+    </filter>
+    <filter id="glow2" x="108" y="92" width="136" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="16" result="effect1_foregroundBlur" />
+    </filter>
+    <filter id="glow3" x="84" y="52" width="88" height="88" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2" result="effect1_foregroundBlur" />
+    </filter>
+  </defs>
+</svg>

--- a/index.html
+++ b/index.html
@@ -683,6 +683,23 @@
 
           <a
             class="game-card card-surface frame-stack"
+            href="./phase-pulse/"
+            role="listitem"
+            data-status="new"
+          >
+            <span class="card-chip">New</span>
+            <div class="card-thumb" aria-hidden="true">
+              <img src="./assets/thumbnails/phase-pulse.svg" alt="" loading="lazy" />
+            </div>
+            <div class="card-meta">
+              <span>Lane Flux Duel</span>
+              <h2>Phase Pulse</h2>
+              <p>Phase between neon lanes, thread the gates, and build a limitless streak in the flux stream.</p>
+            </div>
+          </a>
+
+          <a
+            class="game-card card-surface frame-stack"
             href="./neon-memory/"
             role="listitem"
             data-status="new"

--- a/phase-pulse/game.js
+++ b/phase-pulse/game.js
@@ -1,0 +1,466 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+const overlay = document.querySelector('[data-overlay]');
+const startButton = document.querySelector('[data-start]');
+const scoreEl = document.querySelector('[data-score]');
+const streakEl = document.querySelector('[data-streak]');
+const bestEl = document.querySelector('[data-best]');
+const surgeEl = document.querySelector('[data-surge]');
+
+const LANES = [140, 240, 340];
+const PLAYER_X = 180;
+const PLAYER_RADIUS = 18;
+const SURGE_TARGET = 1;
+
+const storageKey = 'phase-pulse-best-score';
+let bestScore = Number.parseInt(localStorage.getItem(storageKey) ?? '0', 10) || 0;
+bestEl.textContent = bestScore.toString();
+
+const state = {
+  running: false,
+  time: 0,
+  speed: 260,
+  score: 0,
+  streak: 0,
+  surge: 0,
+  surgeMode: false,
+  surgeTime: 0,
+  spawnTimer: 0,
+  spawnInterval: 1,
+  entities: [],
+  gateCooldown: 0,
+};
+
+const player = {
+  laneIndex: 1,
+  y: LANES[1],
+  targetLane: 1,
+  transition: 0,
+};
+
+function resetRun() {
+  state.time = 0;
+  state.speed = 260;
+  state.score = 0;
+  state.streak = 0;
+  state.surge = 0;
+  state.surgeMode = false;
+  state.surgeTime = 0;
+  state.spawnTimer = 0;
+  state.spawnInterval = 1;
+  state.entities = [];
+  state.gateCooldown = 0;
+  player.laneIndex = 1;
+  player.targetLane = 1;
+  player.y = LANES[1];
+  player.transition = 0;
+  updateHUD();
+  updateSurgeBar();
+}
+
+function startRun() {
+  resetRun();
+  overlay.hidden = true;
+  state.running = true;
+}
+
+function endRun() {
+  state.running = false;
+  overlay.hidden = false;
+  overlay.querySelector('h2').textContent = 'Run Over';
+  overlay.querySelector('p').textContent = 'You clipped a mine. Smash restart to chase a hotter streak.';
+  overlay.querySelector('button').textContent = 'Run Again';
+  if (state.score > bestScore) {
+    bestScore = state.score;
+    localStorage.setItem(storageKey, String(bestScore));
+  }
+  bestEl.textContent = bestScore.toString();
+}
+
+function updateHUD() {
+  scoreEl.textContent = Math.round(state.score).toString();
+  streakEl.textContent = state.streak.toString();
+}
+
+function updateSurgeBar() {
+  const pct = Math.min(state.surge / SURGE_TARGET, 1) * 100;
+  surgeEl.style.width = `${pct}%`;
+}
+
+function cycleLane(direction) {
+  if (!state.running) return;
+  const next = (player.targetLane + direction + LANES.length) % LANES.length;
+  player.targetLane = next;
+}
+
+function snapLane(index) {
+  if (!state.running) return;
+  if (index < 0 || index >= LANES.length) return;
+  player.targetLane = index;
+}
+
+function spawnEntity() {
+  const roll = Math.random();
+  if (roll < 0.55) {
+    const lane = Math.floor(Math.random() * LANES.length);
+    state.entities.push({
+      type: 'orb',
+      x: canvas.width + 60,
+      lane,
+      radius: 12,
+      pulse: Math.random() * Math.PI * 2,
+    });
+  } else if (roll < 0.85 || state.gateCooldown > 0) {
+    const lane = Math.floor(Math.random() * LANES.length);
+    state.entities.push({
+      type: 'hazard',
+      x: canvas.width + 60,
+      lane,
+      radius: 16,
+      spin: Math.random() * Math.PI * 2,
+    });
+  } else {
+    const openLane = Math.floor(Math.random() * LANES.length);
+    state.entities.push({
+      type: 'gate',
+      x: canvas.width + 80,
+      width: 70,
+      openLane,
+      hit: false,
+    });
+    state.gateCooldown = 2.5;
+  }
+}
+
+function updateEntities(dt) {
+  const speedMultiplier = state.surgeMode ? 1.25 : 1;
+  const velocity = state.speed * dt * speedMultiplier;
+  for (const entity of state.entities) {
+    entity.x -= velocity;
+    if (entity.type === 'orb') {
+      entity.pulse += dt * 6;
+    }
+    if (entity.type === 'hazard') {
+      entity.spin += dt * 5;
+    }
+  }
+  state.entities = state.entities.filter((entity) => entity.x > -120);
+}
+
+function handleCollisions() {
+  for (const entity of state.entities) {
+    if (entity.type === 'orb' && entity.lane === player.targetLane) {
+      if (entity.x < PLAYER_X + PLAYER_RADIUS && entity.x > PLAYER_X - PLAYER_RADIUS) {
+        collectOrb(entity);
+      }
+    } else if (entity.type === 'hazard' && entity.lane === player.targetLane) {
+      if (Math.abs(entity.x - PLAYER_X) < PLAYER_RADIUS + entity.radius - 4) {
+        crash();
+        return;
+      }
+    } else if (entity.type === 'gate') {
+      if (!entity.hit && entity.x < PLAYER_X + PLAYER_RADIUS && entity.x + entity.width > PLAYER_X - PLAYER_RADIUS) {
+        if (player.targetLane !== entity.openLane) {
+          crash();
+          return;
+        } else {
+          entity.hit = true;
+        }
+      }
+    }
+  }
+}
+
+function collectOrb(orb) {
+  state.entities = state.entities.filter((entity) => entity !== orb);
+  state.streak += 1;
+  const combo = 1 + state.streak * 0.12;
+  const surgeBoost = state.surgeMode ? 2 : 1;
+  state.score += 12 * combo * surgeBoost;
+  state.surge += 0.11;
+  if (!state.surgeMode && state.surge >= SURGE_TARGET) {
+    state.surgeMode = true;
+    state.surgeTime = 6;
+    state.surge = SURGE_TARGET;
+  }
+  state.speed = Math.min(state.speed + 4.5, 420);
+  state.spawnInterval = Math.max(0.45, state.spawnInterval - 0.015);
+  updateHUD();
+  updateSurgeBar();
+}
+
+function crash() {
+  state.streak = 0;
+  state.surge = 0;
+  state.surgeMode = false;
+  updateHUD();
+  updateSurgeBar();
+  endRun();
+}
+
+function updatePlayer(dt) {
+  const current = player.laneIndex;
+  const target = player.targetLane;
+  if (current !== target) {
+    player.transition += dt * 6;
+    if (player.transition >= 1) {
+      player.transition = 0;
+      player.laneIndex = target;
+      player.y = LANES[target];
+    } else {
+      const startY = LANES[current];
+      const targetY = LANES[target];
+      player.y = startY + (targetY - startY) * easeInOut(player.transition);
+    }
+  } else {
+    player.y = LANES[current];
+    player.transition = 0;
+  }
+}
+
+function easeInOut(t) {
+  return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+}
+
+let lastTime = 0;
+
+function loop(timestamp) {
+  const dt = Math.min((timestamp - lastTime) / 1000 || 0, 0.033);
+  lastTime = timestamp;
+
+  if (state.running) {
+    state.time += dt;
+    state.spawnTimer += dt;
+    if (state.gateCooldown > 0) {
+      state.gateCooldown -= dt;
+    }
+    if (state.spawnTimer >= state.spawnInterval) {
+      state.spawnTimer = 0;
+      spawnEntity();
+    }
+
+    if (state.surgeMode) {
+      state.surgeTime -= dt;
+      state.surge = SURGE_TARGET;
+      if (state.surgeTime <= 0) {
+        state.surgeMode = false;
+        state.surge = 0;
+      }
+      updateSurgeBar();
+    } else {
+      state.surge = Math.max(0, state.surge - dt * 0.04);
+      updateSurgeBar();
+    }
+
+    updatePlayer(dt);
+    updateEntities(dt);
+    handleCollisions();
+  }
+
+  draw();
+  requestAnimationFrame(loop);
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  drawBackground();
+  drawEntities();
+  drawPlayer();
+  if (state.running) {
+    drawSpeedLines();
+  }
+}
+
+function drawBackground() {
+  const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  gradient.addColorStop(0, '#030616');
+  gradient.addColorStop(1, '#05091f');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.save();
+  ctx.globalAlpha = 0.18;
+  ctx.strokeStyle = '#6ee7ff';
+  ctx.lineWidth = 2;
+  LANES.forEach((laneY, index) => {
+    ctx.beginPath();
+    drawRoundedRect(ctx, 70, laneY - 36, canvas.width - 140, 72, 28);
+    ctx.stroke();
+
+    ctx.fillStyle = index === player.targetLane ? 'rgba(126, 255, 254, 0.08)' : 'rgba(110, 231, 255, 0.03)';
+    ctx.fill();
+  });
+  ctx.restore();
+}
+
+function drawEntities() {
+  for (const entity of state.entities) {
+    if (entity.type === 'orb') {
+      drawOrb(entity);
+    } else if (entity.type === 'hazard') {
+      drawHazard(entity);
+    } else if (entity.type === 'gate') {
+      drawGate(entity);
+    }
+  }
+}
+
+function drawOrb(orb) {
+  const y = LANES[orb.lane];
+  const radius = orb.radius + Math.sin(orb.pulse) * 2;
+  const gradient = ctx.createRadialGradient(orb.x, y, radius * 0.2, orb.x, y, radius);
+  gradient.addColorStop(0, 'rgba(255, 255, 255, 0.9)');
+  gradient.addColorStop(0.45, '#7bfffe');
+  gradient.addColorStop(1, 'rgba(123, 255, 255, 0.05)');
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.arc(orb.x, y, radius, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+function drawHazard(hazard) {
+  const y = LANES[hazard.lane];
+  ctx.save();
+  ctx.translate(hazard.x, y);
+  ctx.rotate(hazard.spin);
+  ctx.beginPath();
+  ctx.moveTo(0, -18);
+  ctx.lineTo(14, 0);
+  ctx.lineTo(0, 18);
+  ctx.lineTo(-14, 0);
+  ctx.closePath();
+  ctx.fillStyle = '#ff5c97';
+  ctx.shadowColor = '#ff5c97';
+  ctx.shadowBlur = 18;
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawGate(gate) {
+  const laneHeight = 72;
+  const gapHeight = laneHeight * 0.86;
+  ctx.fillStyle = 'rgba(255, 92, 151, 0.08)';
+  ctx.strokeStyle = 'rgba(255, 92, 151, 0.5)';
+  ctx.lineWidth = 3;
+
+  LANES.forEach((laneY, index) => {
+    if (index === gate.openLane) {
+      ctx.save();
+      ctx.globalAlpha = 0.25;
+      ctx.fillStyle = 'rgba(126, 255, 254, 0.22)';
+      ctx.fillRect(gate.x - gate.width / 2, laneY - gapHeight / 2, gate.width, gapHeight);
+      ctx.restore();
+      return;
+    }
+    ctx.beginPath();
+    drawRoundedRect(
+      ctx,
+      gate.x - gate.width / 2,
+      laneY - laneHeight / 2,
+      gate.width,
+      laneHeight,
+      12
+    );
+    ctx.fill();
+    ctx.stroke();
+  });
+}
+
+function drawPlayer() {
+  const x = PLAYER_X;
+  const y = player.y;
+
+  const gradient = ctx.createRadialGradient(x, y, 4, x, y, PLAYER_RADIUS + 6);
+  gradient.addColorStop(0, '#ffffff');
+  gradient.addColorStop(0.35, '#7bfffe');
+  gradient.addColorStop(1, 'rgba(123, 255, 255, 0.1)');
+
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.arc(x, y, PLAYER_RADIUS, 0, Math.PI * 2);
+  ctx.fill();
+
+  if (state.surgeMode) {
+    ctx.save();
+    ctx.globalAlpha = 0.35;
+    ctx.strokeStyle = '#74f7ff';
+    ctx.lineWidth = 6;
+    ctx.beginPath();
+    ctx.arc(x, y, PLAYER_RADIUS + 12 + Math.sin(state.time * 6) * 4, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.restore();
+  }
+}
+
+function drawSpeedLines() {
+  ctx.save();
+  ctx.globalAlpha = state.surgeMode ? 0.3 : 0.18;
+  ctx.strokeStyle = state.surgeMode ? '#7bfffe' : 'rgba(123, 255, 255, 0.6)';
+  ctx.lineWidth = 2;
+  const spacing = state.surgeMode ? 48 : 72;
+  const offset = (state.time * state.speed) % spacing;
+  for (let x = -spacing + spacing - offset; x < canvas.width; x += spacing) {
+    ctx.beginPath();
+    ctx.moveTo(x, 80);
+    ctx.lineTo(x + 14, canvas.height - 80);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawRoundedRect(context, x, y, width, height, radius) {
+  if (context.roundRect) {
+    context.roundRect(x, y, width, height, radius);
+    return;
+  }
+
+  const r = typeof radius === 'number'
+    ? { tl: radius, tr: radius, br: radius, bl: radius }
+    : { tl: 0, tr: 0, br: 0, bl: 0, ...radius };
+
+  context.moveTo(x + r.tl, y);
+  context.lineTo(x + width - r.tr, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + r.tr);
+  context.lineTo(x + width, y + height - r.br);
+  context.quadraticCurveTo(x + width, y + height, x + width - r.br, y + height);
+  context.lineTo(x + r.bl, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - r.bl);
+  context.lineTo(x, y + r.tl);
+  context.quadraticCurveTo(x, y, x + r.tl, y);
+  context.closePath();
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.key === 'ArrowUp' || event.key === 'w' || event.key === 'W') {
+    event.preventDefault();
+    cycleLane(-1);
+  } else if (event.key === 'ArrowDown' || event.key === 's' || event.key === 'S') {
+    event.preventDefault();
+    cycleLane(1);
+  } else if (event.key === ' ' || event.code === 'Space') {
+    event.preventDefault();
+    cycleLane(1);
+  } else if (event.key === '1') {
+    snapLane(0);
+  } else if (event.key === '2') {
+    snapLane(1);
+  } else if (event.key === '3') {
+    snapLane(2);
+  }
+});
+
+canvas.addEventListener('pointerdown', () => {
+  if (!state.running) {
+    startRun();
+  } else {
+    cycleLane(1);
+  }
+});
+
+startButton.addEventListener('click', () => {
+  startRun();
+});
+
+resetRun();
+requestAnimationFrame(loop);

--- a/phase-pulse/index.html
+++ b/phase-pulse/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase Pulse · Pixel Playground</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="layout">
+      <section class="hud">
+        <header class="hud__intro">
+          <a class="hud__back" href="../">← Cabinet Select</a>
+          <h1>Phase Pulse</h1>
+          <p>
+            Lane shift through a neon flux stream. Tap <kbd>W</kbd>/<kbd>S</kbd> or the arrow keys to
+            phase between lanes, snag the energy pulses, and dodge the static mines. Fill the surge
+            meter for a scoring frenzy—miss once and the run implodes.
+          </p>
+        </header>
+        <div class="hud__stats">
+          <div>
+            <span>Score</span>
+            <strong data-score>0</strong>
+          </div>
+          <div>
+            <span>Streak</span>
+            <strong data-streak>0</strong>
+          </div>
+          <div>
+            <span>Best</span>
+            <strong data-best>0</strong>
+          </div>
+          <div class="surge">
+            <span>Surge</span>
+            <div class="surge__bar" aria-hidden="true">
+              <div class="surge__fill" data-surge></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="playfield">
+        <canvas id="game" width="720" height="480" aria-label="Phase Pulse arena"></canvas>
+        <div class="overlay" data-overlay>
+          <h2>Tap to Phase In</h2>
+          <p>Press <kbd>Space</kbd> to hop lanes. Thread the pulses. Chase the infinite combo.</p>
+          <button type="button" data-start>Start Run</button>
+        </div>
+      </section>
+    </main>
+
+    <script src="./game.js" type="module"></script>
+  </body>
+</html>

--- a/phase-pulse/style.css
+++ b/phase-pulse/style.css
@@ -1,0 +1,193 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: #05060f;
+  --panel: rgba(12, 18, 48, 0.78);
+  --accent: #7bfffe;
+  --accent-strong: #74f7ff;
+  --danger: #ff5c97;
+  --good: #8fff6c;
+  --text-muted: rgba(226, 230, 255, 0.64);
+  --text-strong: rgba(255, 255, 255, 0.94);
+  background: radial-gradient(circle at top, rgba(36, 59, 125, 0.24), transparent 60%), var(--bg);
+  min-height: 100%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+}
+
+.layout {
+  width: min(1080px, 95vw);
+  display: grid;
+  gap: clamp(1.5rem, 2.5vw, 2.75rem);
+  padding: clamp(1.5rem, 3vw, 3rem);
+  background: rgba(5, 9, 27, 0.78);
+  border: 1px solid rgba(123, 209, 255, 0.1);
+  border-radius: 28px;
+  box-shadow: 0 40px 80px rgba(3, 8, 27, 0.55);
+  backdrop-filter: blur(18px);
+}
+
+.hud {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.hud__intro {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hud__back {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.hud__back:hover,
+.hud__back:focus-visible {
+  opacity: 1;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  color: var(--text-strong);
+}
+
+p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+kbd {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.85em;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.15);
+}
+
+.hud__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.hud__stats div {
+  background: var(--panel);
+  border-radius: 18px;
+  padding: 1rem 1.15rem;
+  border: 1px solid rgba(123, 209, 255, 0.08);
+  display: grid;
+  gap: 0.35rem;
+  align-content: start;
+}
+
+.hud__stats span {
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.hud__stats strong {
+  font-size: clamp(1.4rem, 2vw, 1.8rem);
+  color: var(--text-strong);
+  font-weight: 600;
+}
+
+.surge {
+  gap: 0.65rem;
+}
+
+.surge__bar {
+  width: 100%;
+  height: 10px;
+  background: rgba(100, 120, 188, 0.35);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.surge__fill {
+  width: 0%;
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  transition: width 200ms ease;
+}
+
+.playfield {
+  position: relative;
+}
+
+canvas {
+  display: block;
+  width: min(720px, 90vw);
+  height: auto;
+  border-radius: 22px;
+  border: 1px solid rgba(123, 209, 255, 0.25);
+  background: radial-gradient(circle at top, rgba(123, 209, 255, 0.12), rgba(5, 8, 27, 0.95));
+  box-shadow: inset 0 0 40px rgba(4, 12, 38, 0.85);
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  gap: 1rem;
+  padding: 2rem;
+  background: rgba(3, 5, 16, 0.82);
+  border-radius: 22px;
+  border: 1px solid rgba(123, 209, 255, 0.2);
+  transition: opacity 250ms ease, visibility 250ms ease;
+}
+
+.overlay[hidden] {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.overlay button {
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #05060f;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  cursor: pointer;
+  transition: transform 120ms ease;
+}
+
+.overlay button:active {
+  transform: scale(0.97);
+}
+
+.overlay h2 {
+  margin: 0;
+  color: var(--text-strong);
+}
+
+@media (max-width: 720px) {
+  .layout {
+    padding: 1.5rem;
+  }
+
+  .hud__stats {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- add the new Phase Pulse cabinet with surge scoring and lane-shifting gameplay
- design dedicated HUD shell, canvas renderer, and local best tracking for the new game
- create supporting thumbnail artwork and surface the game on the arcade homepage and README

## Testing
- `python -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68d96290ef24832c93202c38df70075e