### PR TITLE
Fix gate collision detection in Phase Pulse

### DIFF
--- a/phase-pulse/game.js
+++ b/phase-pulse/game.js
@@ -159,7 +159,10 @@ function handleCollisions() {
         return;
       }
     } else if (entity.type === 'gate') {
-      if (!entity.hit && entity.x < PLAYER_X + PLAYER_RADIUS && entity.x + entity.width > PLAYER_X - PLAYER_RADIUS) {
+      const halfWidth = entity.width / 2;
+      const gateLeft = entity.x - halfWidth;
+      const gateRight = entity.x + halfWidth;
+      if (!entity.hit && gateLeft < PLAYER_X + PLAYER_RADIUS && gateRight > PLAYER_X - PLAYER_RADIUS) {
         if (player.targetLane !== entity.openLane) {
           crash();
           return;


### PR DESCRIPTION
## Summary
- correct the gate collision bounds to account for the gate's centered position
- ensure players only collide with the closed portions of a gate while the open lane remains safe

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e80f4bce04832c992cf1c516c33b0f